### PR TITLE
GSBug debug names

### DIFF
--- a/cgi.pas
+++ b/cgi.pas
@@ -170,6 +170,7 @@ var
    codeGeneration: boolean;		{is code generation on?}
    commonSubexpression: boolean; 	{do common subexpression removal?}
    debugFlag: boolean;			{generate debugger calls?}
+   debugStrFlag: boolean;               {gsbug/niftylist debug names?}
    floatCard: integer;			{0 -> SANE; 1 -> FPE}
    floatSlot: integer;			{FPE slot}
    isDynamic: boolean;			{are segments dynamic?}
@@ -686,6 +687,7 @@ stringSize := 0; 			{no strings, yet}
 rangeCheck := false;			{don't generate range checks}
 profileFlag := false;			{don't generate profiling code}
 debugFlag := false;			{don't generate debug code}
+debugStrFlag := false;                  {don't generate gsbug debug strings}
 traceBack := false;			{don't generate traceback code}
 
 registers := cLineOptimize;		{don't do register optimizations}

--- a/gen.pas
+++ b/gen.pas
@@ -4089,11 +4089,24 @@ procedure GenTree {op: icptr};
    end; {GenDviMod}
 
 
-   procedure GenEnt;
-
    { Generate code for a pc_ent					}
+   procedure GenEnt(op: icptr);
+   var
+     i: integer;
+     len: integer;
 
    begin {GenEnt}
+
+   if debugStrFlag then begin
+     len := length(op^.lab^);
+     CnOut(m_brl);
+     CnOut2(len + 3);
+     CnOut2($7771);
+     CnOut(len);
+     for i := 1 to len do
+       CnOut(ord(op^.lab^[i]));
+   end;
+
    if rangeCheck then begin		{if range checking is on, check for a stack overflow}
       GenNative(m_pea, immediate, localSize - returnSize - 1, nil, 0);
       GenCall(129);
@@ -5644,7 +5657,7 @@ case op^.opcode of
    pc_dec,pc_inc: GenIncDec(op, nil);
    pc_dif,pc_int,pc_uni: GenDifIntUni(op);
    pc_dvi,pc_mod,pc_udi,pc_uim: GenDviMod(op);
-   pc_ent: GenEnt;
+   pc_ent: GenEnt(op);
    pc_equ,pc_neq: GenEquNeq(op, op^.opcode, 0);
    pc_fix: GenFix(op);
    pc_fjp,pc_tjp: GenFjpTjp(op);

--- a/parser.pas
+++ b/parser.pas
@@ -4356,7 +4356,8 @@ end; {DoConstant}
     Gen0(dc_pin)
   else {imbeded procedure}
     Gen1(dc_lab, fprocp^.pfname);
-  Gen0(pc_ent);				{create a stack frame}
+  Gen1Name(pc_ent, 0, fprocp^.name); {create a stack frame}
+
   ResetTemp;				{forget old temporary variables}
 
   lcp := fprocp^.pfparms;		{generate code for passed parameters}

--- a/scanner.pas
+++ b/scanner.pas
@@ -694,6 +694,7 @@ var
    debugFlag := odd(val);
    profileFlag := (val & $0002) <> 0;
    profileFlag := profileFlag or debugFlag;
+   debugStrFlag := (val & $8000) <> 0;
    end; {DoDebug}
 
 


### PR DESCRIPTION
This patch adds support for inline procedure names, a non-intrusive debug method supported by GSBug and NiftyList. See IIgs technote #103 for more information.

Setting bit 15 (`$8000`) of the `{$debug}` directive enables inline names, ie `{$debug $8000}`