### PR TITLE
Adding Tool.Interface code to the repo.

### DIFF
--- a/Tool.Interface/ACE.pas
+++ b/Tool.Interface/ACE.pas
@@ -1,0 +1,57 @@
+{$keep 'ACE'}
+unit ACE;
+interface
+
+{********************************************************
+*
+*  ACE Tool Set Interface File (Apple IIGS Audio
+*                               Compression and Expansion)
+*
+*  Other USES Files Needed:  Common
+*
+*  Other Tool Sets Needed:   Tool Locator
+*
+*  Copyright 1987-1992
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common;
+
+
+procedure ACEBootInit; tool ($1D, $01);    (* WARNING: an application should
+                                                       NEVER make this call *)
+
+procedure ACEStartup (zeroPageLoc: integer); tool ($1D, $02);
+
+procedure ACEShutdown; tool ($1D, $03);
+
+function ACEVersion: integer; tool ($1D, $04);
+
+procedure ACEReset; tool ($1D, $05);       (* WARNING: an application should
+                                                       NEVER make this call *)
+
+function ACEStatus: boolean; tool ($1D, $06);
+
+function ACEInfo (infoItemCode: integer): longint; tool ($1D, $07);
+
+procedure ACECompBegin; tool ($1D, $0B);
+
+procedure ACECompress (src: handle; srcOffset: longint; dest: handle;
+                       destOffset: longint; nBlks, method: integer);
+tool ($1D, $09);
+
+procedure ACEExpand (src: handle; srcOffset: longint; dest: handle;
+                     destOffset: longint; nBlks, method: integer);
+tool ($1D, $0A);
+
+procedure ACEExpBegin; tool ($1D, $0C);
+
+function GetACEExpState: ptr; tool ($1D, $0D);
+
+procedure SetACEExpState (buffer: ptr); tool ($1D, $0E);
+
+implementation
+end.

--- a/Tool.Interface/Build
+++ b/Tool.Interface/Build
@@ -1,0 +1,13 @@
+set list        Common ACE ControlMgr DeskMgr DeskTopBus DialogMgr EventMgr
+set list {list} Finder QuickDrawII FontMgr GSOS HyperStudio HyperXCMD
+set list {list} IntegerMath LineEdit ListMgr MemoryMgr MenuMgr MIDI MIDISynth
+set list {list} MscToolSet MultiMedia ObjIntf ORCAShell PrintMgr ProDOS
+set list {list} ResourceMgr Scheduler ScrapMgr Sequencer SFToolSet SoundMgr
+set list {list} Synthesizer TextEdit TextToolSet ToolLocator WindowMgr 
+
+for i in {list}
+   echo Processing {i}
+   compile +t +e {i}.pas
+   copy -c {i}.int  2/orcapascaldefs/
+   delete {i}.int {i}.a
+end

--- a/Tool.Interface/Common.pas
+++ b/Tool.Interface/Common.pas
@@ -1,0 +1,510 @@
+{$keep 'Common'}
+unit Common;
+interface
+
+{********************************************************
+*
+*  Common Types Interface File
+*
+*  Other USES Files Needed: - None -
+*
+*  Copyright 1987-1992
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+const
+   {Reference verbs describing parameter type.}
+   pointerVerb     =   $0000;           {parm is pointer to block of data}
+   handleVerb      =   $0001;           {parm is handle of block of data}
+   resourceVerb    =   $0002;           {parm is resource ID}
+   newHandleVerb   =   $0003;           {tool is to create new handle}
+
+   {TaskMaster/Event Manager result codes}
+   nullEvt         =   $0000;
+   inNull          =   $0000;
+   wNoHit          =   $0000;
+   mouseDownEvt    =   $0001;
+   inButtDwn       =   $0001;
+   mouseUpEvt      =   $0002;
+   keyDownEvt      =   $0003;
+   inKey           =   $0003;
+   autoKeyEvt      =   $0005;
+   updateEvt       =   $0006;
+   inUpdate        =   $0006;
+   activateEvt     =   $0008;
+   switchEvt       =   $0009;
+   deskAccEvt      =   $000A;
+   driverEvt       =   $000B;
+   app1Evt         =   $000C;
+   app2Evt         =   $000D;
+   app3Evt         =   $000E;
+   app4Evt         =   $000F;
+   wInDesk         =   $0010;      {in desktop}
+   wInMenuBar      =   $0011;      {in system menu bar}
+   wClickCalled    =   $0012;      {system click called}
+   wInContent      =   $0013;      {in content region of window}
+   wInDrag         =   $0014;      {in drag region of window}
+   wInGrow         =   $0015;      {in grow box of active window}
+   wInGoAway       =   $0016;      {in close box of active window}
+   wInZoom         =   $0017;      {in zoom box of active window}
+   wInInfo         =   $0018;      {in information bar of window}
+   wInSpecial      =   $0019;      {item ID selected was 250-255}
+   wInDeskItem     =   $001A;      {item ID selected was 1-249}
+   wInFrame        =   $001B;      {in frame, but not on anything else}
+   wInactMenu      =   $001C;      {inactive menu item selected}
+   wClosedNDA      =   $001D;      {desk accessory closed}
+   wCalledSysEdit  =   $001E;      {inactive menu item selected}
+   wTrackZoom      =   $001F;      {zoom box clicked, but not selected}
+   wHitFrame       =   $0020;      {button down on frame, made active}
+   wInControl      =   $0021;      {button or keystroke in control}
+   wInSysWindow    =   $8000;      {high-order bit set for system windows}
+
+type
+   {GS/OS class 1 input string}
+   gsosInString = record
+       size:  integer;
+      {Change the array size as needed for your application}
+       theString:  packed array [1..254] of char;
+       end;
+   gsosInStringPtr = ^gsosInString;
+
+   {GS/OS class 1 output string}
+   gsosOutString = record
+       maxSize:    integer;
+       theString:  gsosInString;
+       end;
+   gsosOutStringPtr = ^gsosOutString;
+
+   {GS/OS option list}
+   optionListRecord = record
+      totalSize: integer;
+      requiredSize: integer;
+      fileSysID: integer;
+     {Change size of theData as needed}
+      theData: packed array [1..100] of char;
+      end;
+   optionListPtr = ^optionListRecord;
+
+   {GS/OS time field}
+   timeField = array[1..8] of byte;
+
+   {ProDOS 16 pathname}
+   pathName = packed array [0..128] of char;
+   pathPtr = ^pathName;
+
+   {String with a length byte}
+   pString = packed array [0..255] of char;
+   pStringPtr = ^pString;
+
+   {Null-terminated string}
+   cString = packed array [1..256] of char;
+   cStringPtr = ^cString;
+
+   {Unterminated text; length specified separately. Array size can be}
+   {adjusted by user.}
+   textBlock = packed array [1..300] of char;
+   textPtr = ^textBlock;
+
+   {"General" types to circumvent type checking by the compiler}
+   ptr        = ^byte;
+   handle     = ^ptr;
+   rgnHandle  = handle;
+   procPtr    = ptr;
+   integerPtr = ^integer;
+   longintPtr = ^longint;
+   fixed      = longint;
+
+   {Point}
+   point = record
+       v: integer;
+       h: integer;
+       end;
+   pointPtr = ^point;
+
+   {Rectangle}
+   rectKinds = (normal, mac, points);
+
+   rect = record
+     case rectKinds of
+       normal:  (v1: integer;
+                 h1: integer;
+                 v2: integer;
+                 h2: integer);
+
+       mac:     (top:    integer;
+                 left:   integer;
+                 bottom: integer;
+                 right:  integer);
+
+       points:  (topLeft:  point;
+                 botRight: point);
+       end;
+   rectPtr = ^rect;
+
+   {Color table}
+   colorTable     = array [0..15] of integer;
+   colorTblPtr    = ^colorTable;
+   colorTablePtr  = ^colorTable;
+   colorTableHndl = ^ColorTablePtr;
+   
+   {Event record}
+   eventRecord = record
+       eventWhat:      integer;
+       eventMessage:   longint;
+       eventWhen:      longint;
+       eventWhere:     point;
+       eventModifiers: integer;
+
+  {The following fields are required by TaskMaster.  They can be removed }
+  {(but do not have to be) if you are not using TaskMaster.              }
+
+       taskData:       longint;
+       taskMask:       longint;
+       lastClickTick:  longint;
+       ClickCount:     integer;
+       TaskData2:      longint;
+       TaskData3:      longint;
+       TaskData4:      longint;
+       lastClickPt:    point;
+       end;
+   eventRecPtr = ^eventRecord;
+   wmTaskRec   = eventRecord;
+
+   {Pattern}
+   pattern = array [0..31] of byte;
+   patternPtr = ^pattern;
+
+   {Font record}
+   font = record
+       offsetToMF:  integer;
+       family:      integer;
+       style:       integer;
+       size:        integer;
+       version:     integer;
+       fbrExtent:   integer;
+       highowTLoc:  integer;
+   {                                                                    }
+   {The rest of the font record cannot be easily accessed from Pascal,  }
+   {as it is intended to change dynamically at run-time.  The record is }
+   {included here for completeness.                                     }
+   {                                                                    }
+   {Array of bytes, as defined by the user:                             }
+   {                                                                    }
+   { additionalFields: array [0..n] of byte;                            }
+   {                                                                    }
+   { fontType: integer;               - ignored on the AppleIIgs -      }
+   {                                                                    }
+   { firstChar:   integer;                                              }
+   { lastChar:    integer;                                              }
+   { widMax:      integer;                                              }
+   { kernMax:     integer;                                              }
+   { nDescent:    integer;                                              }
+   { fRectWidth:  integer;                                              }
+   { fRectHeight: integer;                                              }
+   { owTLoc:      integer;                                              }
+   { ascent:      integer;                                              }
+   { descent:     integer;                                              }
+   { leading:     integer;                                              }
+   { rowWords:    integer;                                              }
+   {                                                                    }
+   {Three arrays, as defined by the user:                               }
+   {                                                                    }
+   { bitImage: array [1..rowWords, 1..fRectHeight] of integer;          }
+   { locTable: array [firstChar..lastChar+2] of integer;                }
+   { owTable:  array [firstChar..lastChar+2] of integer;                }
+
+       end;
+   fontRec = ^font;
+   fontHndl = ^fontRec;
+
+   {Location information record}
+   locInfo = record
+       portSCB:          integer;
+       ptrToPixelImage:  ptr;
+       width:            integer;
+       boundsRect:       rect;
+       end;
+   locInfoPtr = ^locInfo;
+
+   {Mask}
+   mask = array [0..7] of byte;
+   maskPtr = ^mask;
+
+   {Font ID}
+   fontID = record
+       famNum: integer;
+       fontStyle, fontSize: byte;
+       end;
+
+   {Font stats record}
+   fontStatRec = record
+       resultID:    fontID;
+       resultStats: integer;
+       end;
+   fontStatRecPtr = ^fontStatRec;
+
+   ctlPtr = ^ctlRec;
+   ctlRecHndl = ^ctlPtr;
+
+   {Graphics port}
+   grafPort = record
+       portInfo:   locInfo;
+       portRect:   rect;
+       clipRgn:    rgnHandle;
+       visRgn:     rgnHandle;
+       bkPat:      pattern;
+       pnLoc:      point;
+       pnSize:     point;
+       pnMode:     integer;
+       pnPat:      pattern;
+       pnMask:     mask;
+       pnVis:      integer;
+       fontHandle: fontHndl;
+       theFontID:  fontID;
+       fontFlags:  integer;
+       txSize:     integer;
+       txFace:     integer;
+       txMode:     integer;
+       spExtra:    fixed;
+       chExtra:    fixed;
+       fgColor:    integer;
+       bgColor:    integer;
+       picSave:    handle;
+       rgnSave:    handle;
+       polySave:   handle;
+       grafProcs:  ptr;
+       arcRot:     integer;
+       userField:  longint;
+       sysField:   longint;
+     {These additional fields are used by the Window Manager.}
+       wDefProc:    longint;
+       wRefCon:     longint;
+       wContDraw:   longint;
+       wReserved:   longint;
+       wStructRgn:     rgnHandle;
+       wContRgn:       rgnHandle;
+       wUpdateRgn:     rgnHandle;
+       wControl:       ctlRecHndl;
+       wFrameControl:  ctlRecHndl;
+       wFrame:         integer;
+       end;
+   grafPortPtr = ^grafPort;
+
+   {Member record}
+   memRec = record
+       memPtr:  pStringPtr;
+       memFlag: byte;
+   {Rest is defined by user}
+       end;
+   memRecPtr = ^memRec;
+
+   {Scroll bar color table}
+   barColors = record
+       barOutline:   integer;
+       barNorArrow:  integer;
+       barSelArrow:  integer;
+       barArrowBack: integer;
+       barNorThumb:  integer;
+       barSelThumb:  integer;
+       barPageRgn:   integer;
+       barInactive:  integer;
+       end;
+   barColorsPtr = ^barColors;
+
+   {Menu record}
+   menu = record
+       menuID:     integer;
+       menuWidth:  integer;
+       menuHeight: integer;
+       menuProc:   procPtr;
+       menuFlag:   byte;
+       menuRes:    byte;
+       numOfItems: integer;
+       titleWidth: integer;
+       titleName:  pStringPtr;
+       menuCache:  handle;
+       end;
+   menuPtr = ^menu;
+   menuHandle = ^menuPtr;
+
+   textList = record
+       cachedHandle: longint;
+       cachedOffset: longint;
+       end;
+
+   superHandle = record
+       cachedHandle:  longint;
+       cachedOffset:  longint;
+       cachedIndex:   integer;
+       end;
+
+   teStyle = record
+       teFont:     fontID;
+       foreColor:  integer;
+       backColor:  integer;
+       userData:   longint;
+       end;
+
+   keyRecord = record
+       theChar:         integer;
+       theModifiers:    integer;
+       theInputHandle:  longint;
+       cursorOffset:    longint;
+       theOpCode:       integer;
+       end;
+
+   keyEquivRec = record
+       key1:          byte;
+       key2:          byte;
+       keyModifiers:  integer;
+       keyCareBits:   integer;
+       end;
+
+   ctlType = (generic, btnOrCheck, icon, lnEdPicGrow, list, popUp, scroll,
+              staticText, textEdit);
+
+   {Control record}
+   ctlRec = record
+       ctlNext:   ctlRecHndl;
+       ctlOwner:  grafPortPtr;
+       ctlRect:   rect;
+       ctlFlag:   byte;
+       ctlHilite: byte;
+       ctlValue:  integer;
+       ctlProc:   procPtr;
+       ctlAction: procPtr;
+       ctlData:   longint;
+       ctlRefCon: longint;
+       ctlColor:  colorTblPtr;
+   {These new fields have been added for GS/OS 5.0 calls.}
+       case ctlType of
+           generic:      (ctlReserved:      packed array [0..15] of byte;
+                          ctlID:            longint;
+                          ctlMoreFlags:     integer;
+                          ctlVersion:       integer);
+
+           btnOrCheck:   (keyEquiv1:        keyEquivRec;
+                          reserved1:        packed array [1..10] of byte;
+                          ctlID1:           longint;
+                          ctlMoreFlags1:    integer;
+                          ctlVersion1:      integer);
+
+           icon:         (keyEquiv2:        keyEquivRec;
+                          reserved2:        packed array [1..10] of byte;
+                          ctlID2:           longint;
+                          ctlMoreFlags2:    integer;
+                          ctlVersion2:      integer;
+                          iconRef:          longint;
+                          displayMode:      integer);
+
+           lnEdPicGrow:  (reserved3:        packed array [1..10] of byte;
+                          ctlID3:           longint;
+                          ctlMoreFlags3:    integer;
+                          ctlVersion3:      integer);
+
+           list:         (ctlMemDraw:       procPtr;
+                          ctlMemHeight:     integer;
+                          ctlMemSize:       integer;
+                          ctlListRef:       longint;
+                          ctlListBar:       ctlRecHndl;
+                          ctlID4:           longint;
+                          ctlMoreFlags4:    integer;
+                          ctlVersion4:      integer);
+
+           popUp:        (menuRef:          longint;
+                          menuEnd:          longint;
+                          popUpRect:        rect;
+                          ctlID5:           longint;
+                          ctlMoreFlags5:    integer;
+                          ctlVersion5:      integer;
+                          titleWidth:       integer);
+
+           scroll:       (thumbRect:        rect;
+                          pageRegion:       rect;
+                          ctlID6:           longint;
+                          ctlMoreFlags6:    integer;
+                          ctlVersion6:      integer);
+
+           staticText:   (ctlJust:          integer;
+                          reserved7:        packed array [1..14] of byte;
+                          ctlID7:           longint;
+                          ctlMoreFlags7:    integer;
+                          ctlVersion7:      integer);
+
+           textEdit:     (textFlags:        longint;
+                          textLength:       longint;
+                          blockList:        textList;
+                          ctrlID8:          integer;
+                          ctrlMoreFlags8:   integer;
+                          ctrlVersion8:     integer;
+                          viewRect:         rect;
+                          totalHeight:      longint;
+                          lineSuper:        superHandle;
+                          styleSuper:       superHandle;
+                          styleList:        handle;
+                          rulerList:        handle;
+                          lineAtEndFlag:    integer;
+                          selectionStart:   longint;
+                          selectionEnd:     longint;
+                          selectionActive:  integer;
+                          selectionState:   integer;
+                          caretTime:        longint;
+                          nullStyleActive:  integer;
+                          nullStyle:        teStyle;
+                          topTextOffset:    longint;
+                          topTextVPos:      integer;
+                          vertScrollBar:    ctlRecHndl;
+                          vertScrollPos:    longint;
+                          vertScrollMax:    longint;
+                          vertScrollAmount: integer;
+                          horzScrollBar:    ctlRecHndl;
+                          horzScrollPos:    longint;
+                          horzScrollMax:    longint;
+                          horzScrollAmount: integer;
+                          growBoxHandle:    ctlRecHndl;
+                          maximumChars:     longint;
+                          maximumLines:     longint;
+                          maxCharsPerLine:  integer;
+                          maximumHeight:    integer;
+                          textDrawMode:     integer;
+                          wordBreakHook:    procPtr;
+                          wordWrapHook:     procPtr;
+                          keyFilter:        procPtr;
+                          theFilterRect:    rect;
+                          theBufferVPos:    integer;
+                          theBufferHPos:    integer;
+                          theKeyRecord:     keyRecord;
+                          cachedSelcOffset: longint;
+                          cachedSelcVPos:   integer;
+                          cachedSelcHPos:   integer;
+                          mouseRect:        rect;
+                          mouseTime:        longint;
+                          mouseKind:        integer;
+                          lastClick:        longint;
+                          savedHPos:        integer;
+                          anchorPoint:      longint);
+       end;
+
+   {Menu bar record}
+   menuBar = record
+       ctlNext:   ctlRecHndl;
+       ctlOwner:  grafPortPtr;
+       ctlRect:   rect;
+       ctlFlag:   byte;
+       ctlHilite: byte;
+       ctlValue:  integer;
+       ctlProc:   procPtr;
+       ctlAction: procPtr;
+       ctlData:   longint;
+       ctlRefCon: longint;
+       ctlColor:  colorTblPtr;
+   {Change size of array for application}
+       menuList:  array [1..10] of menuHandle;
+       end;
+   menuBarPtr = ^menuBar;
+   menuBarHandle = ^menuBarPtr;
+
+implementation
+end.

--- a/Tool.Interface/Common.pas
+++ b/Tool.Interface/Common.pas
@@ -66,7 +66,7 @@ type
    gsosInString = record
        size:  integer;
       {Change the array size as needed for your application}
-       theString:  packed array [1..254] of char;
+       theString:  packed array [1..508] of char;
        end;
    gsosInStringPtr = ^gsosInString;
 

--- a/Tool.Interface/ControlMgr.pas
+++ b/Tool.Interface/ControlMgr.pas
@@ -1,0 +1,547 @@
+{$keep 'ControlMgr'}
+unit ControlMgr;
+interface
+
+{********************************************************
+*
+*  Control Manager Interface File
+*
+*  Other USES files needed:  Common
+*
+*  Other Tool Sets Needed:  Tool Locator, Memory Manager,
+*                           Miscellaneous Tool Set, Quick Draw II,
+*                           Event Manager, Window Manager,
+*                           LineEdit Tool Set (if using StatTextControl
+*                           or LineEditControl), QDAuxilliary Tool Set
+*                           (if using PictureControl or IconButtonControl),
+*                           TextEdit Tool Set (if using TextEditControl),
+*                           Menu Manager (if using PopUpControl), List
+*                           Manager (if using ListControl).
+*
+*
+*  Copyright 1987-1992, 1993
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common;
+
+const
+  ctlInVis         =   $0080;          (* invisible mask for any type ctl *)
+
+  (* Simple button control flag values *)
+  simpRound        =   $0000;          (* single outlined, round cornered  *)
+  simpBRound       =   $0001;          (* bold outlined, round cornered    *)
+  simpSquare       =   $0002;          (* single outlined, square cornered *)
+  simpDropSquare   =   $0003;          (* single outlined, square cornered,*)
+                                       (* drop shadowed                    *)
+
+  family           =   $007F;          (* radio button family number *)
+
+  (* Scroll bar control flag values *)
+  upFlag           =   $0001;          (* up arrow on scroll bar    *)
+  downFlag         =   $0002;          (* down arrow on scroll bar  *)
+  leftFlag         =   $0004;          (* left arrow on scroll bar  *)
+  rightFlag        =   $0008;          (* right arrow on scroll bar *)
+  horScroll        =   $0010;          (* horizontal scroll bar     *)
+
+  (* Standard Control procedures *)
+  SimpleProc       =   $00000000;      (* simple button standard control *)
+  CheckProc        =   $02000000;      (* simple check-box std control   *)
+  RadioProc        =   $04000000;      (* radio button standard control  *)
+  ScrollProc       =   $06000000;      (* scroll bar standard control    *)
+  GrowProc         =   $08000000;      (* size box standard control      *)
+
+  (* NewControl2 procRef values for standard control types *)
+  cSimpleButtonControl =  $80000000;
+  cCheckControl        =  $82000000;
+  cRadioControl        =  $84000000;
+  cScrollBarControl    =  $86000000;
+  cGrowControl         =  $88000000;
+  cStatTextControl     =  $81000000;
+  cEditLineControl     =  $83000000;
+  cEditTextControl     =  $85000000;
+  cPopUpControl        =  $87000000;
+  cListControl         =  $89000000;
+  cIconButtonControl   =  $07FF0001;
+  cPictureControl      =  $8D000000;
+
+  (* DefProc message parameters *)
+  drawCtl          =   $00;            (* draw the control                   *)
+  calcCRect        =   $01;            (* compute the rectangle to drag      *)
+  testCtl          =   $02;            (* test where mouse button pressed    *)
+  initCtl          =   $03;            (* perform additional control init    *)
+  dispCtl          =   $04;            (* take additional disposal actions   *)
+  posCtl           =   $05;            (* move control's indicator           *)
+  thumbCtl         =   $06;            (* compute parms for dragging indic.  *)
+  dragCtl          =   $07;            (* drag either indicator or control   *)
+  autoTrack        =   $08;            (* called while dragging if -1 passed *)
+                                       (* to TrackControl                    *)
+  newValue         =   $09;            (* called when ctl gets new value     *)
+  setParams        =   $0A;            (* called when ctl gets add. parms    *)
+  moveCtl          =   $0B;            (* called when control moves          *)
+  recSize          =   $0C;            (* return ctl record size in bytes    *)
+
+  ctlHandleEvent    =  $0D;            (* handle keystrokes/menu selections  *)
+  ctlChangeTarget   =  $0E;            (* make control active/inactive       *)
+  ctlChangeBounds   =  $0F;            (* change bounds rectangle of control *)
+  ctlWindChangeSize =  $10;            (* window has grown or been zoomed    *)
+  ctlHandleTab      =  $11;            (* control was tabbed to              *)
+  ctlNotifyMultiPart = $12;            (* multipart control must be hidden,  *)
+                                       (*   drawn, or shown                  *)
+  ctlWinStateChange =  $13;            (* window state has changed           *)
+
+ 
+  (* axis parameters *)
+  noConstraint     =   $0000;          (* no movement constraint              *)
+  hAxisOnly        =   $0001;          (* constrain movement to horiz. axis   *)
+  vAxisOnly        =   $0002;          (* constrain movement to vertical axis *)
+
+  (* part codes *)
+  NoPart           =   $00;            (* no part                  *)
+  SimpleButton     =   $02;            (* simple button            *)
+  CheckBox         =   $03;            (* check box                *)
+  RadioButton      =   $04;            (* radio button             *)
+  UpArrow          =   $05;            (* up arrow on scroll bar   *)
+  DownArrow        =   $06;            (* down arrow on scroll bar *)
+  PageUp           =   $07;            (* page up                  *)
+  PageDown         =   $08;            (* page down                *)
+  GrowBox          =   $0A;            (* size box                 *)
+  Thumb            =   $81;            (* thumb                    *)
+
+(* Hilite control parameters *)
+noHilite           =   $0000;          (* hilight control                *)
+inactiveHilite     =   $00FF;          (* remove hilighting from control *)
+
+(* Control Manager constants (upper 8 bits) of ctlMoreFlags field *)
+fCtlTarget         =   $8000;      (* ctl is currently active control        *)
+fCtlCanBeTarget    =   $4000;      (* ctl can be made active control         *)
+fCtlWantEvents     =   $2000;      (* call ctl when SendEventToCtl activated *)
+fCtlProcRefNotPtr  =   $1000;      (* if set, ProcRef = ID of def proc rtn,  *)
+                                   (*   else ProcRef = ptr to defproc rtn    *)
+fCtlTellAboutSize  =   $0800;      (* notify ctl when window size changes    *)
+fCtlIsMultiPart    =   $0400;      (* notify ctl needs to be hidden          *)
+
+(* defProc constants (lower 8 bits) of ctlMoreFlags field *)
+
+(* Bits 0 and 1 describe title reference: *)
+titleIsPtr         = $0;
+titleIsHandle      = $1;
+titleIsResource    = $2;
+
+(* Bits 2 and 3 describe the color table reference: *)
+colorTableIsPtr      = $0;
+colorTableIsHandle   = $4;
+colorTableIsResource = $8;
+
+
+type
+   (* Control record is defined in the Common.intf interface file *)
+
+   (* Scroll bar color table is defined in the Common.intf interface file *)
+
+   boxColors = record                  (* check box color table *)
+       boxReserved: integer;
+       boxNor:      integer;
+       boxSel:      integer;
+       boxTitle:    integer;
+       end;
+
+   bttnColors = record                  (* button color table *)
+       bttnOutline: integer;
+       bttnNorBack: integer;
+       bttnSelBack: integer;
+       bttnNorText: integer;
+       bttnSelText: integer;
+       end;
+
+   limitBlk = record                    (* limit block *)
+       boundRect: rect;
+       slopRect:  rect;
+       axisParam: integer;
+       dragPatt:  ptr;
+       end;
+
+   radioColors = record                 (* radio button color table *)
+       radReserved: integer;
+       radNor:      integer;
+       radSel:      integer;
+       radTitle:    integer;
+       end;
+
+   (* Control templates *)
+   customControl = record
+       pCount:      integer;
+       ID:          longint;
+       boundsRect:  rect;
+       procRef:     longint;
+       flag:        integer;
+       moreFlags:   integer;
+       refCon:      longint;
+   (* This block is user-defined:  set your own limit. *)
+       data:        packed array [0..255] of byte;
+       end;
+
+   simpleButtonControl = record
+       pCount:       integer;
+       ID:           longint;
+       boundsRect:   rect;
+       procRef:      longint;
+       flag:         integer;
+       moreFlags:    integer;
+       refCon:       longint;
+       titleRef:     longint;
+       colorTblRef:  longint;          (* optional *)
+       keyEquiv:     keyEquivRec;      (* optional *)
+       end;
+            
+   checkOrRadioControl = record
+       pCount:       integer;
+       ID:           longint;
+       boundsRect:   rect;
+       procRef:      longint;
+       flag:         integer;
+       moreFlags:    integer;
+       refCon:       longint;
+       titleRef:     longint;
+       initialValue: integer;
+       colorTblRef:  longint;          (* optional *)
+       keyEquiv:     keyEquivRec;      (* optional *)
+       end;
+            
+   scrollControl = record
+       pCount:       integer;
+       ID:           longint;
+       boundsRect:   rect;
+       procRef:      longint;
+       flag:         integer;
+       moreFlags:    integer;
+       refCon:       longint;
+       maxSize:      integer;
+       viewSize:     integer;
+       initialValue: integer;
+       colorTblRef:  longint;          (* optional *)
+       end;
+            
+   statTextControl = record
+       pCount:       integer;
+       ID:           longint;
+       boundsRect:   rect;
+       procRef:      longint;
+       flag:         integer;
+       moreFlags:    integer;
+       refCon:       longint;
+       textRef:      longint;
+       textSize:     integer;          (* optional *)
+       just:         integer;          (* optional *)
+       end;
+            
+   editLineControl = record
+       pCount:       integer;
+       ID:           longint;
+       boundsRect:   rect;
+       procRef:      longint;
+       flag:         integer;
+       moreFlags:    integer;
+       refCon:       longint;
+       maxSize:      integer;
+       defaultRef:   longint;
+       end;
+            
+   editTextControl = record
+       pCount:          integer;
+       controlID:       longint;
+       boundsRect:      rect;
+       procRef:         longint;       (* must be $85000000 *)
+       flags:           integer;
+       moreflags:       integer;
+       refCon:          longint;
+       textFlags:       longint;
+       indentRect:      rect;          (* this, and the rest of the fields, *)
+       vertBar:         longint;       (*   are optional                    *)
+       vertAmount:      integer;
+       horzBar:         longint;       (* reserved - set to nil *)
+       horzAmount:      integer;       (* reserved - set to 0   *)
+       styleRef:        longint;
+       textDescriptor:  integer;
+       textRef:         longint;
+       textLength:      longint;
+       maxChars:        longint;
+       maxLines:        longint;
+       maxCharsPerLine: integer;
+       maxHeight:       integer;
+       colorRef:        longint;
+       drawMode:        integer;
+       filterProcPtr:   procPtr;
+       end;
+
+   popUpControl = record
+       pCount:       integer;
+       ID:           longint;
+       boundsRect:   rect;
+       procRef:      longint;
+       flag:         integer;
+       moreFlags:    integer;
+       refCon:       longint;
+       titleWidth:   integer;
+       menuRef:      longint;
+       initialValue: integer;
+       colorRef:     longint;          (* optional *)
+       end;
+            
+   listControl = record
+       pCount:         integer;
+       ID:             longint;
+       boundsRect:     rect;
+       procRef:        longint;
+       flag:           integer;
+       moreFlags:      integer;
+       refCon:         longint;
+       listSize:       integer;
+       listView:       integer;
+       listType:       integer;
+       listStart:      integer;
+       listDraw:       procPtr;
+       listMemHeight:  integer;
+       listMemSize:    integer;
+       listRef:        longint;
+       colorRef:       longint;
+       end;
+            
+   growControl = record
+       pCount:       integer;
+       ID:           longint;
+       boundsRect:   rect;
+       procRef:      longint;
+       flag:         integer;
+       moreFlags:    integer;
+       refCon:       longint;
+       colorRef:     longint;          (* optional *)
+       end;
+
+   pictureControl = record
+       pCount:       integer;
+       ID:           longint;
+       boundsRect:   rect;
+       procRef:      longint;
+       flag:         integer;
+       moreFlags:    integer;
+       refCon:       longint;
+       pictureRef:   longint;
+       end;
+            
+   iconButtonControl = record
+       pCount:       integer;
+       ID:           longint;
+       boundsRect:   rect;
+       procRef:      longint;
+       flag:         integer;
+       moreFlags:    integer;
+       refCon:       longint;
+       iconRef:      longint;
+       titleRef:     longint;          (* optional *)
+       colorTblRef:  longint;          (* optional *)
+       displayMode:  integer;          (* optional *)
+       keyEquiv:     keyEquivRec;      (* optional *)
+       end;
+
+   rectangleControl = record
+       pCount:       integer;
+       ID:           longint;
+       boundsRect:   rect;
+       procRef:      longint;
+       flag:         integer;
+       moreFlags:    integer;
+       refCon:       longint;
+       penHeight:    integer;
+       penWidth:     integer;
+       penMask:      mask;
+       penPattern:   pattern;
+       end;
+
+   thermometerControl = record
+       pCount:       integer;
+       ID:           longint;
+       boundsRect:   rect;
+       procRef:      longint;
+       flag:         integer;
+       moreFlags:    integer;
+       refCon:       longint;
+       value:        integer;
+       data:         integer;
+       colorTblRef:  longint;          (* optional *)
+       end;
+
+
+
+procedure CtlBootInit; tool ($10, $01);    (* WARNING: an application should
+                                                       NEVER make this call *)
+
+procedure CtlStartup (userID, dPageAddr: integer); tool ($10, $02);
+
+procedure CtlShutDown; tool ($10, $03);
+
+function CtlVersion: integer; tool ($10, $04);
+
+procedure CtlReset; tool ($10, $05);   (* WARNING: an application should
+                                                   NEVER make this call *)
+
+function CtlStatus: boolean; tool ($10, $06);
+
+function CallCtlDefProc (theControl: ctlRecHndl; message: integer;
+                         param: univ longint): longint; tool ($10, $2C);
+
+function CMLoadResource (resourceType: integer; resourceID: longint): handle;
+tool ($10, $32);                        (* WARNING: an application should
+                                                    NEVER make this call *)
+                     
+procedure CMReleaseResource (resourceType: integer; resourceID: longint);
+tool ($10, $33);                        (* WARNING: an application should
+                                                    NEVER make this call *)
+
+procedure CtlNewRes; tool ($10, $12);
+
+procedure DisposeControl (theControl: ctlRecHndl); tool ($10, $0A);
+
+procedure DragControl (startX, startY: integer;
+                       var limitRectPtr, slopRectPtr: rect; axis: integer;
+                       theControl: ctlRecHndl); tool ($10, $17);
+
+(* DragRect returns 2 integers; the hi word = amt X changed; *)
+(*                              the lo word = amt Y changed  *)
+
+function DragRect (actionProc: procPtr; var dragPattern: pattern;
+                   startX, startY: integer;
+                   var dragRect, limitRect, slopRect: rect;
+                   dragFlag: integer): longint; tool ($10, $1D);
+
+procedure DrawControls (theWindow: grafPortPtr); tool ($10, $10);
+
+procedure DrawOneCtl (theControl: ctlRecHndl); tool ($10, $25);
+
+procedure EraseControl (theControl: ctlRecHndl); tool ($10, $24);
+
+function FindControl (var foundCtlPtr: ctlRecHndl; pointX, pointY: integer;
+                      theWindow: grafPortPtr): integer; tool ($10, $13);
+
+function FindRadioButton (theWindow: grafPortPtr; famNum: integer): integer;
+tool ($10, $39);
+
+function FindTargetCtl: ctlRecHndl; tool ($10, $26);
+
+function GetCtlAction (theControl: ctlRecHndl): procPtr; tool ($10, $21);
+
+function GetCtlHandleFromID (theWindow: grafPortPtr; ctlID: univ longint):
+                             ctlRecHndl; tool ($10, $30);
+                     
+function GetCtlID (theControl: ctlRecHndl): longint; tool ($10, $2A);
+
+function GetCtlDPage: integer; tool ($10, $1F);
+
+function GetCtlMoreFlags (theControl: ctlRecHndl): integer; tool ($10, $2E);
+                     
+function GetCtlParamPtr: longint; tool ($10, $35);
+
+(* GetCtlParams returns 2 integers: both are values of additional ctl parms *)
+
+function GetCtlParams (theControl: ctlRecHndl): longint; tool ($10, $1C);
+
+function GetCtlRefCon (theControl: ctlRecHndl): longint; tool ($10, $23);
+
+function GetCtlTitle (theControl: ctlRecHndl): pStringPtr; tool ($10, $0D);
+
+function GetCtlValue (theControl: ctlRecHndl): integer; tool ($10, $1A);
+
+procedure GetLETextByID (theWindow: grafPortPtr; controlID: longint;
+   var text: pString); tool ($10, $3B);
+
+(* GrowSize returns 2 integers: lo word = height; hi word = width *)
+
+function GrowSize: longint; tool ($10, $1E);
+
+procedure HideControl (theControl: ctlRecHndl); tool ($10, $0E);
+
+procedure HiliteControl (hiliteState: integer; theControl: ctlRecHndl);
+tool ($10, $11);
+
+procedure InvalCtls (theWindow: grafPortPtr); tool ($10, $37);
+
+procedure KillControls (theWindow: grafPortPtr); tool ($10, $0B);
+
+function MakeNextCtlTarget: ctlRecHndl; tool ($10, $27);
+
+procedure MakeThisCtlTarget (theControl: ctlRecHndl); tool ($10, $28);
+
+procedure MoveControl (newX, newY: integer; theControl: ctlRecHndl);
+tool ($10, $16);
+
+function NewControl (theWindow: grafPortPtr; var boundsRect: rect;
+                     title: univ pStringPtr;
+                     flag, value, param1, param2: integer;
+                     defProc: univ longint; refCon: longint;
+                     ctlColorTable: colorTblPtr): ctlRecHndl;
+tool ($10, $09);
+
+function NewControl2 (theWindow: grafPortPtr; referenceDesc: integer;
+                      reference: univ longint): ctlRecHndl; tool ($10, $31);
+
+procedure NotifyCtls (mask, message: integer; param: univ longint;
+                      theWindow: grafportptr); tool ($10, $2D);
+                     
+function SendEventToCtl (targetOnlyFlag: boolean; theWindow: grafPortPtr;
+                         var eTaskRecPtr: eventRecord): boolean;
+tool ($10, $29);
+                             
+procedure SetCtlAction (newAction: procPtr; theControl: ctlRecHndl);
+tool ($10, $20);
+
+function SetCtlIcons (newFontHandle: fontHndl): fontHndl; tool ($10, $18);
+
+procedure SetCtlID (newID: longint; theControl: ctlRecHndl); tool ($10, $2B);
+
+procedure SetCtlMoreFlags (newMoreFlags: integer; theControl: ctlRecHndl);
+tool ($10, $2F);
+                     
+procedure SetCtlParamPtr (subArrayptr: univ longint); tool ($10, $34);
+
+procedure SetCtlParams (param2, param1: integer; theControl: ctlRecHndl);
+tool ($10, $1B);
+
+procedure SetCtlRefCon (newRefCon: longint; theControl: ctlRecHndl);
+tool ($10, $22);
+
+procedure SetCtlTitle (titlePtr: univ pStringPtr; theControl: ctlRecHndl);
+tool($10, $0C);
+
+procedure SetCtlValue (curValue: integer; theControl: ctlRecHndl);
+tool ($10, $19);
+
+procedure SetLETextByID (windPtr: grafPortPtr; leCtlID: longint;
+   text: pString); tool ($10, $3A);
+
+procedure ShowControl (theControl: ctlRecHndl); tool ($10, $0F);
+
+function TestControl (pointX, pointY: integer; theControl: ctlRecHndl): integer;
+tool ($10, $14);
+
+function TrackControl (startX, startY: integer; actionProc: procPtr;
+                       theControl: ctlRecHndl): integer; tool ($10, $15);
+
+{new in 6.0.1}
+
+procedure SetCtlValueByID (curValue: integer; theWindow: grafPortPtr;
+                           theID: longint); tool ($10, $3C);
+
+function GetCtlValueByID (theWindow: grafPortPtr; theID: longint): integer;
+tool ($10, $3D);
+
+procedure InvalOneCtlByID (theWindow: grafPortPtr; theID: longint);
+tool ($10, $3E);
+
+procedure HiliteCtlByID (hiliteState: integer; theWindow: grafPortPtr;
+                         theID:longint); tool ($10, $3F);
+
+implementation
+end.

--- a/Tool.Interface/DeskMgr.pas
+++ b/Tool.Interface/DeskMgr.pas
@@ -1,0 +1,160 @@
+{$keep 'DeskMgr'}
+unit DeskMgr;
+interface
+
+{********************************************************
+*
+*   Desk Manager Interface File
+*
+*   Other USES Files Needed:  Common
+*
+*   Other Tool Sets Needed:   Tool Locator, Memory Manager,
+*                             Miscellaneous Tool Set, Quick Draw II,
+*                             Event Manager, Window Manager, Menu Manager,
+*                             Control Manager, LineEdit Tool Set,
+*                             Dialog Manager, Scrap Manager
+*
+*  Copyright 1987-1992
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common;
+
+const
+   (* NDA action codes *)
+   eventAction     =   $0001;      (* code for event to be handled by NDA  *)
+   runAction       =   $0002;      (* code passed when time period elapsed *)
+   cursorAction    =   $0003;      (* code if NDA is frontmost window      *)
+   undoAction      =   $0005;      (* code when user selects Undo          *)
+   cutAction       =   $0006;      (* code when user selects Cut           *)
+   copyAction      =   $0007;      (* code when user selects Copy          *)
+   pasteAction     =   $0008;      (* code when user selects Paste         *)
+   clearAction     =   $0009;      (* code when user selects Clear         *)
+
+   (* edit types *)
+   undoEdit        =   $0001;      (* Undo edit type  *)
+   cutEdit         =   $0002;      (* Cut edit type   *)
+   copyEdit        =   $0003;      (* Copy edit type  *)
+   pasteEdit       =   $0004;      (* Paste edit type *)
+   clearEdit       =   $0005;      (* Clear edit type *)
+
+
+type
+   CDA_ID = record
+       DAName:     pString;
+       DAstart:    procPtr;
+       DAShutDown: procPtr;
+       end;
+   CDA_IDPtr = ^CDA_ID;
+   CDA_IDHandle = ^CDA_IDPtr;
+
+   NDA_ID = record
+       openRtn:   procPtr;
+       closeRtn:  procPtr;
+       actionRtn: procPtr;
+       initRtn:   procPtr;
+       period:    integer;
+       eventMask: integer;
+       menuText:  cString;
+       end;
+   NDA_IDPtr = ^NDA_ID;
+   NDA_IDHandle = ^NDA_IDPtr;
+
+   stringTable = record
+       titleStr:   cStringPtr;
+       controlStr: cStringPtr;
+       quitStr:    cStringPtr;
+       selectStr:  cStringPtr;
+       end;
+   stringTblPtr = ^stringTable;
+
+   runItem = record
+       reserved:  longint;
+       period:    integer;
+       signature: integer;
+       reserved2: longint;
+       end;
+   runItemPtr = ^runItem;
+         
+        
+procedure DeskBootInit; tool ($05, $01);   (* WARNING: an application should
+                                                       NEVER make this call *)
+
+procedure DeskStartUp; tool ($05, $02);
+
+procedure DeskShutDown; tool ($05, $03);
+
+function DeskVersion: integer; tool ($05, $04);
+
+procedure DeskReset; tool ($05, $05);  (* WARNING: an application should NEVER
+                                                   make this call *)
+
+function DeskStatus: boolean; tool ($05, $06);
+
+procedure AddToRunQ (header: runItemPtr); tool ($05, $1F);
+
+procedure CallDeskAcc (flags: integer; daReference: univ longint;
+   action: integer; bufferPtr: longint); tool ($05, $24);
+
+procedure ChooseCDA; tool ($05, $11);  (* WARNING: an application should NEVER
+                                                   make this call *)
+
+procedure CloseAllNDAs; tool ($05, $1D);
+
+procedure CloseNDA (refNum: integer); tool ($05, $16);
+
+procedure CloseNDAbyWinPtr (theWindow: grafPortPtr); tool ($05, $1C);
+
+procedure FixAppleMenu (menuID: integer); tool ($05, $1E);
+
+procedure GetDeskAccInfo (flags: integer; daReference: univ longint;
+   buffSize: integer; bufferPtr: ptr); tool ($05, $23);
+
+function GetDeskGlobal (selector: integer): longint; tool ($05, $25);
+
+function GetDAStrPtr: stringTblPtr; tool ($05, $14);
+
+function GetNumNDAs: integer; tool ($05, $1B);
+
+procedure InstallCDA (IDHandle: handle); tool ($05, $0F);
+
+procedure InstallNDA (IDHandle: NDA_IDHandle); tool ($05, $0E);
+
+function OpenNDA (DAIDNumber: integer): integer; tool ($05, $15);
+
+procedure RemoveFromRunQ (header: runItemPtr); tool ($05, $20);
+
+procedure RemoveCDA (IDHandle: CDA_IDHandle); tool ($05, $21);
+
+procedure RemoveNDA (IDHandle: NDA_IDHandle); tool ($05, $22);
+
+procedure RestAll; tool ($05, $0C);    (* WARNING: an application should NEVER
+                                                   make this call *)
+
+procedure RestScrn; tool ($05, $0A);   (* WARNING: an application should NEVER
+                                                   make this call *)
+
+procedure SaveAll; tool ($05, $0B);    (* WARNING: an application should
+                                                   NEVER make this call *)
+
+procedure SaveScrn; tool ($05, $09);   (* WARNING: an application should
+                                                   NEVER make this call *)
+
+procedure SetDAStrPtr (altDispHandle: handle; newStrings: stringTblPtr);
+tool ($05, $13);
+
+procedure SystemClick (var theEvent: eventRecord; theWindow: grafPortPtr;
+                       findWindowResult: integer); tool ($05, $17);
+
+function SystemEdit (editType: integer): boolean; tool ($05, $18);
+
+function SystemEvent (eventWhat: integer; eventMessage, eventWhen, eventWhere:
+                      longint; eventMods: integer): boolean; tool ($05, $1A);
+
+procedure SystemTask; tool ($05, $19);
+
+implementation
+end.

--- a/Tool.Interface/DeskTopBus.pas
+++ b/Tool.Interface/DeskTopBus.pas
@@ -1,0 +1,128 @@
+{$keep 'DeskTopBus'}
+unit DeskTopBus;
+interface
+
+{********************************************************
+*
+*  Desktop Bus Tool Set Interface File
+*
+*  Other USES Files Needed: Common
+*
+*  Other Tool Sets Needed: Tool Locator, Memory Manager
+*
+*  Copyright 1987-1990
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common;
+
+const
+   readModes       =   $000A;      (* read modes of ADB command          *)
+   readConfig      =   $000B;      (* read configuration of ADB command  *)
+   readADBError    =   $000C;      (* read ADB error byte of ADB command *)
+   readVersionNum  =   $000D;      (* read version number of ADB command *)
+   readAvailCharSet =  $000E;      (* read available character sets      *)
+   readAvailLayout =   $000F;      (* read available keyboard layouts    *)
+
+   readMicroMem    =   $0009;      (* read data byte from kybd controller *)
+
+   abort           =   $0001;      (* abort; no operation            *)
+   resetKbd        =   $0002;      (* reset keyboard microcontroller *)
+   flushKbd        =   $0003;      (* flush keyboard                 *)
+   setModes        =   $0004;      (* set modes                      *)
+   clearModes      =   $0005;      (* clear modes                    *)
+   setConfig       =   $0006;      (* set configuration              *)
+   synch           =   $0007;      (* synch                          *)
+   writeMicroMem   =   $0008;      (* write microcontroller memory   *)
+   resetSys        =   $0010;      (* reset system                   *)
+   keyCode         =   $0011;      (* send ADB key code              *)
+   resetADB        =   $0040;      (* reset ADB                      *)
+   transmitADBBytes =  $0047;      (* transmit ADB bytes             *)
+   enableSRQ       =   $0050;      (* enable SRQ                     *)
+   flushADBDevBuf  =   $0060;      (* flush buffer on ADB device     *)
+   disableSRQ      =   $0070;      (* disable SRQ                    *)
+   transmit2ADBBytes = $0080;      (* transmit 2 ADB bytes           *)
+   listen          =   $0080;      (* ADB listen command             *)
+   talk            =   $00C0;      (* ADB talk command               *)
+
+type
+   readConfigRec = record
+       rcADBAddr:      byte;
+       rcLayoutOrLang: byte;
+       rcRepeatDelay:  byte;
+       end;
+
+   setConfigRec = record
+       scADBAddr:      byte;
+       scLayoutOrLang: byte;
+       scRepeatDelay:  byte;
+       end;
+
+   synchRec = record
+       synchMode:          byte;
+       synchKybdMouseAddr: byte;
+       synchLayoutOrLang:  byte;
+       synchRepeatDelay:   byte;
+       end;
+
+   scaleRec = record
+       xDivide:   integer;
+       yDivide:   integer;
+       xOffset:   integer;
+       yOffset:   integer;
+       xMultiply: integer;
+       yMultiply: integer;
+       end;
+
+
+procedure ADBBootInit; tool ($09, $01);    (* WARNING:  an application should
+                                                        NEVER make this call *)
+
+procedure ADBStartUp; tool ($09, $02);
+
+procedure ADBShutDown; tool ($09, $03);
+
+function ADBVersion: integer; tool ($09, $04);
+
+procedure ADBReset; tool ($09, $05);    (* WARNING: an application should NEVER
+                                                    NEVER make this call *)
+
+function ADBStatus: boolean; tool ($09, $06);
+
+procedure AbsON; tool ($09, $0F);
+
+procedure AbsOFF; tool ($09, $10);
+
+procedure AsyncADBReceive (compPtr: procPtr; adbCommand: integer);
+tool ($09, $0D);
+
+procedure ClearSRQTable; tool ($09, $16);
+
+procedure GetAbsScale (var dataInPtr: scaleRec); tool ($09, $13);
+
+function ReadAbs: boolean; tool ($09, $11);
+
+procedure ReadKeyMicroData (dataLength: integer; dataPtr: ptr;
+                            adbCommand: integer); tool ($09, $0A);
+
+procedure ReadKeyMicroMemory (dataOutPtr, dataInPtr: ptr;
+                              adbCommand: integer); tool ($09, $0B);
+
+procedure SendInfo (dataLength: integer; dataPtr: ptr; adbCommand: integer);
+tool ($09, $09);
+
+procedure SetAbsScale (var dataOutPtr: scaleRec); tool ($09, $12);
+
+procedure SRQPoll (compPtr: procPtr; adbRegAddr: integer); tool ($09, $14);
+
+procedure SRQRemove (adbRegAddr: integer); tool ($09, $15);
+
+procedure SyncADBReceive (inputWord: integer; compPtr: procPtr;
+                          adbCommand: integer); tool ($09, $0E);
+
+implementation
+
+end.

--- a/Tool.Interface/DialogMgr.pas
+++ b/Tool.Interface/DialogMgr.pas
@@ -1,0 +1,272 @@
+{$keep 'DialogMgr'}
+unit DialogMgr;
+interface
+
+{********************************************************
+*
+*   Dialog Manager Interface File
+*
+*   Other USES Files Needed: Common
+*
+*   Other Tool Sets Needed:  Tool Locator, Memory Manager,
+*                            Miscellaneous Tool Set, Quick Draw II,
+*                            Desk Manager, Event Manager, Window Manager,
+*                            Control Manager, LineEdit Tool Set
+*
+*   Notes:  Any templates, because of their varying format,
+*           must be supplied by the user.
+*
+*  Copyright 1987-1990
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common;
+
+const
+   (* dialog scroll bar commands *)
+   getInitView     =   $0001;          (* view size at creation    *)
+   getInitTotal    =   $0002;          (* total size at creation   *)
+   getInitValue    =   $0003;          (* value at creation        *)
+   scrollLineUp    =   $0004;          (* scroll one line up       *)
+   scrollLineDown  =   $0005;          (* scroll one line down     *)
+   scrollPageUp    =   $0006;          (* scroll one page up       *)
+   scrollPageDown  =   $0007;          (* scroll one page down     *)
+   scrollThumb     =   $0008;          (* scroll to thumb position *)
+
+   (* item types *)
+   buttonItem      =   $000A;          (* standard button control             *)
+   checkItem       =   $000B;          (* standard check box control          *)
+   radioItem       =   $000C;          (* standard radio button control       *)
+   scrollBarItem   =   $000D;          (* special dialog scroll bar           *)
+   userCtlItem     =   $000E;          (* application-defined control         *)
+   statText        =   $000F;          (* static text - cannot be edited      *)
+   longStatText    =   $0010;          (* static text                         *)
+   editLine        =   $0011;          (* text that can be edited             *)
+   iconItem        =   $0012;          (* an icon                             *)
+   picItem         =   $0013;          (* a QuickDrawII picture               *)
+   userItem        =   $0014;          (* application-defined item            *)
+   userCtlItem2    =   $0015;          (* application-defined control         *)
+   longStatText2   =   $0016;          (* static text - text cannot be edited *)
+                                       (* and can contain embedded commands   *)
+   itemDisable     =   $8000;          (* added to any item to disable item   *)
+
+   (* item type range *)
+   minItemType     =   $000A;          (* minimum valid item type *)
+   maxItemType     =   $0016;          (* maximum valid item type *)
+
+   (* item IDs *)
+   OK              =   $0001;
+   Cancel          =   $0002;
+
+   (* part codes *)
+   inButton        =   $0002;          (* user clicked simple button       *)
+   inCheckBox      =   $0003;          (* user clicked check box           *)
+   inRadioButton   =   $0004;          (* user clicked radio button        *)
+   inUpArrow       =   $0005;          (* user clicked up arrow            *)
+   inDownArrow     =   $0006;          (* user clicked down arrow          *)
+   inPageUP        =   $0007;          (* user clicked page-up area        *)
+   inPageDown      =   $0008;          (* user clicked page-down area      *)
+   inStatText      =   $0009;          (* user clicked static text item    *)
+   inGrow          =   $000A;          (* user clicked size box            *)
+   inEditLine      =   $000B;          (* user clicked in text to edit     *)
+   inUserItem      =   $000C;          (* user clicked application item    *)
+   inLongStatText  =   $000D;          (* user clicked longStatText item   *)
+   inIconItem      =   $000E;          (* user clicked an icon             *)
+   inLongStatText2 =   $000F;          (* user clicked longStatText2 item  *)
+   inThumb         =   $0081;          (* user clicked thumb of scroll item *)
+
+   (* stage bit flags *)
+   OKDefault       =   $0000;          (* OK is default for alert     *)
+   CancelDefault   =   $0040;          (* Cancel is default for alert *)
+   AlertDrawn      =   $0080;          (* draw alert                  *)
+
+type
+   itemTemplate = record
+       itemID:    integer;
+       itemRect:  rect;
+       itemType:  integer;
+       itemDescr: ptr;
+       itemValue: integer;
+       itemFlag:  integer;
+       itemColor: colorTblPtr;
+       end;
+   itemTempPtr = ^itemTemplate;
+
+   alertTemplate = record
+       atBoundsRect: rect;
+       atAlertID:    integer;
+       atStage1:     byte;
+       atStage2:     byte;
+       atStage3:     byte;
+       atStage4:     byte;
+  (* This array should be set to reflect the number of items in the alert.   *)
+  (* The last pointer in the array should be NIL to mark the end of the list *)
+       atItemList:   array[1..10] of itemTempPtr;
+       end;
+
+   dialogTemplate = record
+       dtBoundsRect: rect;
+       dtVisible:    boolean;
+       dtRefCon:     longint;
+  (* This array should be set to reflect the number of items in the dialog.  *)
+  (* The last pointer in the array should be NIL to mark the end of the list *)
+       dtItemList:   array[1..10] of itemTempPtr;
+       end;
+   dialogTempPtr = ^dialogTemplate;
+
+   iconRecord = record
+       iconRect:  rect;
+       iconImage: array [1..64] of integer;  (* user can change size of array *)
+       end;
+
+   userCtlItemPB = record
+       defProcParm: procPtr;
+       titleParm:   ptr;
+       param2:      integer;
+       param1:      integer;
+       end;
+
+
+procedure DialogBootInit; tool ($15, $01); (* WARNING: an application should
+                                                       NEVER make this call *)
+
+procedure DialogStartup (UserID: integer); tool ($15, $02);
+
+procedure DialogShutDown; tool ($15, $03);
+
+function DialogVersion: integer; tool ($15, $04);
+
+procedure DialogReset; tool ($15, $05);    (* WARNING: an application should
+                                                       NEVER make this call *)
+
+function DialogStatus: boolean; tool ($15, $06);
+
+function Alert (var theAlertTemplate: alertTemplate;
+                filterProc: procPtr): integer; tool ($15, $17);
+
+function CautionAlert (var theAlertTemplate: alertTemplate;
+                       filterProc: procPtr): integer; tool ($15, $1A);
+
+procedure CloseDialog (theDialog: grafPortPtr); tool ($15, $0C);
+
+function DefaultFilter (theDialog: grafPortPtr; var theEvent: eventRecord;
+                        var itemHitPtr: ptr): boolean; tool ($15, $36);
+
+function DialogSelect (var theEvent: eventRecord; var resultPtr: grafPortPtr;
+                       var itemHit: integer): boolean; tool ($15, $11);
+
+procedure DisableDItem (theDialog: grafPortPtr; itemID: integer); tool ($15, $39);
+
+procedure DlgCopy (theDialog: grafPortPtr); tool ($15, $13);
+
+procedure DlgCut (theDialog: grafPortPtr); tool ($15, $12);
+
+procedure DlgDelete (theDialog: grafPortPtr); tool ($15, $15);
+
+procedure DlgPaste (theDialog: grafPortPtr); tool ($15, $14);
+
+procedure DrawDialog (theDialog: grafPortPtr); tool ($15, $16);
+
+procedure EnableDItem (theDialog: grafPortPtr; itemID: integer); tool ($15, $3A);
+
+procedure ErrorSound (soundProcPtr: procPtr); tool ($15, $09);
+
+function FindDItem (theDialog: grafPortPtr; var thePoint: point): integer;
+tool ($15, $24);
+
+function GetAlertStage: integer; tool ($15, $34);
+
+function GetControlDItem (theDialog: grafPortPtr; itemID: integer): ctlRecHndl;
+tool ($15, $1E);
+
+function GetDefButton (theDialog: grafPortPtr): integer; tool ($15, $37);
+
+procedure GetDItemBox (theDialog: grafPortPtr; itemID: integer;
+                       var itemBoxPtr: rect); tool ($15, $28);
+
+function GetDItemType (theDialog: grafPortPtr; itemID: integer): integer;
+tool ($15, $26);
+
+function GetDItemValue (theDialog: grafPortPtr; itemID: integer): integer;
+tool ($15, $2E);
+
+function GetFirstDItem (theDialog: grafPortPtr): integer; tool ($15, $2A);
+
+procedure GetIText (theDialog: grafPortPtr; itemID: integer; resultPtr:
+                    univ pStringPtr); tool ($15, $1F);
+
+procedure GetNewDItem (theDialog: grafPortPtr;
+                       var theItemTemplate: itemTemplate); tool ($15, $33);
+
+function GetNewModalDialog (var theDialogTemplate: dialogTemplate): grafPortPtr;
+tool ($15, $32);
+
+function GetNextDItem (theDialog: grafPortPtr; itemID: integer): integer;
+tool ($15, $2B);
+
+procedure HideDItem (theDialog: grafPortPtr; itemID: integer); tool ($15, $22);
+
+function IsDialogEvent (var theEvent: eventRecord): boolean; tool ($15, $10);
+
+function ModalDialog (filterProc: procPtr): integer; tool ($15, $0F);
+
+(* ModalDialog2 returns 2 integers: the lo word = item; hi word = part code *)
+
+function ModalDialog2 (filterProc: procPtr): longint; tool ($15, $2C);
+
+procedure NewDItem (theDialog: grafPortPtr; itemID: integer; var itemRect: rect;
+                    itemType: integer; itemDescr: univ longint;
+                    itemValue, itemFlag: integer; itemColor: univ ptr);
+tool ($15, $0D);
+
+function NewModalDialog (var dBoundsRect: rect; dVisibleFlag: boolean;
+                         dRefCon: longint): grafPortPtr; tool ($15, $0A);
+
+function NewModelessDialog (var dBoundsRect: rect; dTitle: pStringPtr;
+                            dBehind: grafPortPtr; dFlag: integer;
+                            dRefCon: longint; var dFullSize: rect): grafPortPtr;
+tool ($15, $0B);
+
+function NoteAlert (var theAlertTemplate: alertTemplate; filterProc: procPtr):
+                    integer; tool ($15, $19);
+
+procedure ParamText (param0, param1, param2, param3: pStringPtr);
+tool ($15, $1B);
+
+procedure RemoveDItem (theDialog: grafPortPtr; itemID: integer); tool ($15, $0E);
+
+procedure ResetAlertStage; tool ($15, $35);
+
+procedure SelectIText (theDialog: grafPortPtr; itemID, startSel,
+                       endSel: integer); tool ($15, $21);
+
+procedure SetDAFont (theFontHandle: fontHndl); tool ($15, $1C);
+
+procedure SetDefButton (defButtonID: integer; theDialog: grafPortPtr);
+tool ($15, $38);
+
+procedure SetDItemBox (theDialog: grafPortPtr; itemID: integer;
+                       var itemBox: rect); tool ($15, $29);
+
+procedure SetDItemType (itemType: integer; theDialog: grafPortPtr;
+                        itemID: integer); tool ($15, $27);
+
+procedure SetDItemValue (itemValue: integer; theDialog: grafPortPtr;
+                         itemID: integer); tool ($15, $2F);
+
+procedure SetIText (theDialog: grafPortPtr; itemID: integer;
+                    theString: pStringPtr); tool ($15, $20);
+
+procedure ShowDItem (theDialog: grafPortPtr; itemID: integer); tool ($15, $23);
+
+function StopAlert (var theAlertTemplate: alertTemplate; filterProc: procPtr):
+                    integer; tool ($15, $18);
+
+procedure UpdateDialog (theDialog: grafPortPtr; updateRgn: rgnHandle);
+tool ($15, $25);
+
+implementation
+end.

--- a/Tool.Interface/EventMgr.pas
+++ b/Tool.Interface/EventMgr.pas
@@ -1,0 +1,131 @@
+{$keep 'EventMgr'}
+unit EventMgr;
+interface
+
+{********************************************************
+*
+*   Event Manager Interface File
+*
+*   Other USES Files Needed: Common
+*
+*   Other Tool Sets Needed:  Tool Locator, Memory Manager,
+*                            Miscellaneous Tool Set, Quick Draw II,
+*                            Desk Manager, ADB Tool Set
+*
+*  Copyright 1987-1990
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common;
+
+const
+   (* Event codes are in the Common.Intf interface file *)
+
+   (* event masks *)
+   mDownMask       =   $0002;      (* call applies to mouse-down events     *)
+   mUpMask         =   $0004;      (* call applies to mouse-up events       *)
+   keyDownMask     =   $0008;      (* call applies to key-down events       *)
+   autoKeyMask     =   $0020;      (* call applies to auto-key events       *)
+   updateMask      =   $0040;      (* call applies to update events         *)
+   activeMask      =   $0100;      (* call applies to activate events       *)
+   switchMask      =   $0200;      (* call applies to switch events         *)
+   deskAccMask     =   $0400;      (* call applies to desk accessory events *)
+   driverMask      =   $0800;      (* call applies to device driver events  *)
+   app1Mask        =   $1000;      (* call applies to application-1 events  *)
+   app2Mask        =   $2000;      (* call applies to application-2 events  *)
+   app3Mask        =   $4000;      (* call applies to application-3 events  *)
+   app4Mask        =   $8000;      (* call applies to application-4 events  *)
+   everyEvent      =   $FFFF;      (* call applies to all events            *)
+
+   (* journal codes *)
+   jcTickCount     =   $00;        (* TickCount call                    *)
+   jcGetMouse      =   $01;        (* GetMouse call                     *)
+   jcButton        =   $02;        (* Button call                       *)
+   jcEvent         =   $04;        (* GetNextEvent and EventAvail calls *)
+
+   (* Modifier flags *)
+   activeFlag    = $0001;          (* set if window was activated        *)
+   changeFlag    = $0002;          (* set if active window changed state *)
+   btn1State     = $0040;          (* set if button 1 was up             *)
+   btn0State     = $0080;          (* set if button 0 was up             *)
+   appleKey      = $0100;          (* set if Apple key was down          *)
+   shiftKey      = $0200;          (* set if Shift key was down          *)
+   capsLock      = $0400;          (* set if Caps Lock key was down      *)
+   optionKey     = $0800;          (* set if Option key was down         *)
+   controlKey    = $1000;          (* set if Control key was down        *)
+   keyPad        = $2000;          (* set if keypress was from key pad   *)
+
+
+
+procedure EMBootInit; tool ($06, $01); (* WARNING: an application should
+                                                   NEVER make this call *)
+
+procedure EMStartUp (dPageAddr, queueSize, xMinClamp, xMaxClamp, yMinClamp,
+                     yMaxClamp, userID: integer); tool ($06, $02);
+
+procedure EMShutDown; tool ($06, $03);
+
+function EMVersion: integer; tool ($06, $04);
+
+procedure EMReset; tool ($06, $05);    (* WARNING: an application should
+                                                   NEVER make this call *)
+
+function EMStatus: boolean; tool ($06, $06);
+
+function Button (buttonNumber: integer): boolean; tool ($06, $0D);
+
+function DoWindows: integer; tool ($06, $09);  (* WARNING: an application should
+                                                   NEVER make this call *)
+
+function EventAvail (eventMask: integer; var theEvent: eventRecord): boolean;
+tool ($06, $0B);
+
+(* FakeMouse's modLatch_padding are 2 separate parameters, each 1 byte in  *)
+(* length.  Use (modLatch  <<  8 | padding)  to create the parameter.      *)
+
+procedure FakeMouse (changedFlag: integer; modLatch_padding: integer;
+                     xPosition, yPosition, buttonStatus: integer);
+tool ($06, $19);
+
+function FlushEvents (eventMask, stopMask: integer): integer; tool ($06, $15);
+
+function GetCaretTime: longint; tool ($06, $12);
+
+function GetDblTime: longint; tool ($06, $11);
+
+function GetKeyTranslation: integer; tool ($06, $1B);
+
+procedure GetMouse (var mouseLocPtr: point); tool ($06, $0C);
+
+function GetNextEvent (eventMask: integer; var theEvent: eventRecord): boolean;
+tool ($06, $0A);
+
+function GetOSEvent (eventMask: integer; var theEvent: eventRecord): boolean;
+tool ($06, $16);
+
+function OSEventAvail (eventMask: integer; var theEvent: eventRecord): boolean;
+tool ($06, $17);
+
+function PostEvent (eventCode: integer; eventMsg: longint): integer;
+tool ($06, $14);
+
+procedure SetAutoKeyLimit (newLimit: integer); tool ($06, $1A);
+
+procedure SetEventMask (systemEventMask: integer); tool ($06, $18);
+
+procedure SetKeyTranslation (kTransID: integer); tool ($06, $1C);
+
+procedure SetSwitch; tool ($06, $13);  (* WARNING: only switcher-type
+                                          applications should make this call *)
+
+function StillDown (buttonNumber: integer): boolean; tool ($06, $0E);
+
+function TickCount: longint; tool ($06, $10);
+
+function WaitMouseUp (buttonNumber: integer): boolean; tool ($06, $0F);
+
+implementation
+end.

--- a/Tool.Interface/Finder.pas
+++ b/Tool.Interface/Finder.pas
@@ -1,0 +1,353 @@
+{$keep 'Finder'}
+unit Finder;
+interface
+
+{********************************************************
+*
+*  Finder data structures and constants
+*
+*  Other USES Files Needed:  Common
+*
+*  Copyright 1992
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common;
+   
+const
+
+   name_of_finder = 'Apple~Finder~';    {target name for SendRequest to Finder}
+
+                                        {SendRequest codes sent by the Finder}
+   finderSaysHello            = $0100;
+   finderSaysGoodbye          = $0101;
+   finderSaysSelectionChanged = $0102;
+   finderSaysMItemSelected    = $0103;
+   finderSaysBeforeOpen       = $0104;
+   finderSaysOpenFailed       = $0105;
+   finderSaysBeforeCopy       = $0106;
+   finderSaysBeforeIdle       = $0107;
+   finderSaysExtrasChosen     = $0108;
+   finderSaysBeforeRename     = $0109;
+   finderSaysKeyHit           = $010A;
+   
+                                        {SendRequest codes sent to the Finder}
+   tellFinderGetDebugInfo      = $8000;
+   askFinderAreYouThere        = $8001;
+   tellFinderAreYouThere       = $8001;
+   tellFinderOpenWindow        = $8002;
+   tellFinderCloseWindow       = $8003;
+   tellFinderGetSelectedIcons  = $8004;
+   tellFinderSetSelectedIcons  = $8005;
+   tellFinderLaunchThis        = $8006;
+   tellFinderShutDown          = $8007;
+   tellFinderMItemSelected     = $8008;
+   tellFinderMatchFileToIcon   = $800A;
+   tellFinderAddBundle         = $800B;
+   tellFinderAboutChange       = $800C;
+   tellFinderCheckDatabase     = $800D;
+   tellFinderColorSelection    = $800E;
+   tellFinderAddToExtras       = $800F;
+   askFinderIdleHowLong        = $8011;
+   tellFinderIdleHowLong       = $8011;
+   tellFinderGetWindowIcons    = $8012;
+   tellFinderGetWindowInfo     = $8013;
+   tellFinderRemoveFromExtras  = $8014;
+   tellFinderSpecialPreference = $8015;
+
+type
+   finderSaysHelloIn = record
+      pCount: integer;
+      version: longint;
+      finderID: integer;
+      iconObjJize: integer;
+      end;
+   finderSaysHelloInPtr = ^finderSaysHelloIn;
+
+   finderSaysMItemSelectedIn = record
+      pCount: integer;
+      menuItemID: integer;
+      menuID: integer;
+      modifiers: integer;
+      end;
+   finderSaysMItemSelectedInPtr = ^finderSaysMItemSelectedIn;
+
+   finderSaysMItemSelectedOut = record
+      recvCount: integer;
+      abortIt: integer;
+      end;
+   finderSaysMItemSelectedOutPtr = ^finderSaysMItemSelectedOut;
+
+   finderSaysBeforeOpenIn = record
+      pCount: integer;
+      pathname: gsosInStringPtr;
+      zoomRect: rectPtr;
+      fileType: integer;
+      auxType: longint;
+      modifiers: integer;
+      theIconObj: ptr;
+      printFlag: boolean;
+      end;
+   finderSaysBeforeOpenInPtr = ^finderSaysBeforeOpenIn;
+   finderSaysOpenFailedIn = finderSaysBeforeOpenIn;
+   finderSaysOpenFailedInPtr = ^finderSaysOpenFailedIn;
+
+   finderSaysBeforeCopyIn = record
+      pCount: integer;
+      inpath: gsosInStringPtr;
+      outpath: gsosOutStringPtr;
+      end;
+   finderSaysBeforeCopyInPtr = ^finderSaysBeforeCopyIn;
+
+   finderSaysBeforeCopyOut = record
+      recvCount: integer;
+      abortFlag: integer;
+      end;
+   finderSaysBeforeCopyOutPtr = ^finderSaysBeforeCopyOut;
+
+   finderSaysBeforeRenameIn = record
+      pCount: integer;
+      oldpath,
+      newpath: gsosInStringPtr;
+      fileType: integer;
+      auxType: longint;
+      end;
+   finderSaysBeforeRenameInPtr = ^finderSaysBeforeRenameIn;
+
+   finderSaysBeforeRenameOut = record
+      recvCount: integer;
+      abortFlag: integer;
+      end;
+   finderSaysBeforeRenameOutPtr = ^finderSaysBeforeRenameOut;
+
+   finderSaysKeyHitIn = record
+      pCount: integer;
+      message: integer;
+      modifiers: integer;
+      end;
+   finderSaysKeyHitInPtr = ^finderSaysKeyHitIn;
+
+   tellFinderGetDebugInfoOut = record
+      recvCount: integer;
+      finderResult: integer;
+      reserved: integer;
+      directPage: integer;
+      deskIcon: handle;
+      nameChainH: handle;
+      filetypeBlock: ptr;
+      deviceBlock: ptr;
+      masterChainH: handle;
+      finderPathsH: handle;
+      finderPathsCount: integer;
+      nameChainInsert: longint;
+      reserved2: longint;
+      masterChainInsert: longint;
+      reserved3: longint;
+      chainTable: handle;
+      iconOffsetArray: handle;
+      iconHandleArray: handle;
+      iconArrayUsed: integer;
+      iconArraySize: integer;
+      reserved4: array[0..64] of byte;
+      end;
+   tellFinderGetDebugInfoOutPtr = ^tellFinderGetDebugInfoOut;
+
+   tellFinderAreYouThereOut = record
+      recvCount: integer;
+      finderResult: integer;
+      end;
+   tellFinderAreYouThereOutPtr = ^tellFinderAreYouThereOut;
+
+   tellFinderOpenWindowOut = record
+      recvCount: integer;
+      finderResult: integer;
+      windowPtr: grafPortPtr;
+      end;
+   tellFinderOpenWindowOutPtr = ^tellFinderOpenWindowOut;
+
+   tellFinderCloseWindowOut = record
+      recvCount: integer;
+      finderResult: integer;
+      end;
+   tellFinderCloseWindowOutPtr = ^tellFinderCloseWindowOut;
+
+   tellFinderGetSelectedIconsOut = record
+      recvCount: integer;
+      finderResult: integer;
+      windowPtr: grafPortPtr;
+      stringListHandle: handle;
+      end;
+   tellFinderGetSelectedIconsOutPtr = ^tellFinderGetSelectedIconsOut;
+
+   tellFinderSetSelectedIconsOut = record
+      recvCount: integer;
+      finderResult: integer;
+      end;
+   tellFinderSetSelectedIconsOutPtr = ^tellFinderSetSelectedIconsOut;
+
+   tellFinderLaunchThisIn = record
+      reserved: integer;
+      pathname: gsosInStringPtr;
+      end;
+   tellFinderLaunchThisInPtr = ^tellFinderLaunchThisIn;
+
+   tellFinderLaunchThisOut = record
+      recvCount: integer;
+      finderResult: integer;
+      end;
+   tellFinderLaunchThisOutPtr = ^tellFinderLaunchThisOut;
+
+   tellFinderShutDownOut = record
+      recvCount: integer;
+      finderResult: integer;
+      end;
+   tellFinderShutDownOutPtr = ^tellFinderShutDownOut;
+
+   tellFinderMItemSelectedIn = record
+      menuItemID: integer;
+      modifiers: integer;
+      flags: integer;
+      end;
+   tellFinderMItemSelectedInPtr = ^tellFinderMItemSelectedIn;
+
+   tellFinderMItemSelectedOut = record
+      recvCount: integer;
+      finderResult: integer;
+      end;
+   tellFinderMItemSelectedOutPtr = ^tellFinderMItemSelectedOut;
+
+   swapLong = record
+      msw,lsw: integer;
+      end;
+
+   tellFinderMatchFileToIconIn = record
+      pCount: integer;
+      vote: integer;
+      match: integer;
+      fileType: integer;
+      auxType: swapLong;
+      fileNamePtr: swapLong;
+      createDateTimePtr: swapLong;
+      modDateTimePtr: swapLong;
+      access: integer;
+      flags: integer;
+      optionPtr: swapLong;
+      combinedEOF: swapLong;
+      end;
+   tellFinderMatchFileToIconInPtr = ^tellFinderMatchFileToIconIn;
+
+   tellFinderMatchFileToIconOut = record
+      recvCount: integer;
+      finderResult: integer;
+      offset: longint;
+      matches: handle;
+      smallIcon: longint;
+      largeIcon: longint;
+      finderPath: handle;
+      end;
+   tellFinderMatchFileToIconOutPtr = ^tellFinderMatchFileToIconOut;
+
+   tellFinderAddBundleIn = record
+      reserved: integer;
+      path1: gsosInStringPtr;
+      path2: gsosInStringPtr;
+      rBundleID: longint;
+      end;
+   tellFinderAddBundleInPtr = ^tellFinderAddBundleIn;
+
+   tellFinderAddBundleOut = record
+      recvCount: integer;
+      finderResult: integer;
+      end;
+   tellFinderAddBundleOutPtr = ^tellFinderAddBundleOut;
+
+   tellFinderAboutChangeOut = record
+      recvCount: integer;
+      finderResult: integer;
+      end;
+   tellFinderAboutChangeOutPtr = ^tellFinderAboutChangeOut;
+
+   ptr68000 = record
+      b3,b2,b1,b0: byte;
+      end;
+
+   tellFinderCheckDatabaseIn = record
+      update: integer;
+      pathName: ptr68000;
+      rVersion: ptr68000;
+      end;
+   tellFinderCheckDatabaseInPtr = ^tellFinderCheckDatabaseIn;
+      
+   tellFinderCheckDatabaseOut = record
+      recvCount: integer;
+      finderResult: integer;
+      found: integer;
+      end;
+   tellFinderCheckDatabaseOutPtr = ^tellFinderCheckDatabaseOut;
+
+   tellFinderColorSelectionOut = record
+      recvCount: integer;
+      finderResult: integer;
+      end;
+   tellFinderColorSelectionOutPtr = ^tellFinderColorSelectionOut;
+   
+   tellFinderAddToExtrasOut = record
+      recvCount: integer;
+      finderResult: integer;
+      menuItemID: integer;
+      menuID: integer;
+      end;
+   tellFinderAddToExtrasOutPtr = ^tellFinderAddToExtrasOut;
+
+   askFinderIdleHowLongOut = record
+      recvCount: integer;
+      finderResult: integer;
+      tickCount: longint;
+      end;
+   askFinderIdleHowLongOutPtr = ^askFinderIdleHowLongOut;
+   tellFinderIdleHowLongOut = askFinderIdleHowLongOut;
+   tellFinderIdleHowLongOutPtr = ^tellFinderIdleHowLongOut;
+
+   tellFinderGetWindowIconsOut = record
+      recvCount: integer;
+      finderResult: integer;
+      stringListHandle: handle;
+      end;
+   tellFinderGetWindowIconsOutPtr = ^tellFinderGetWindowIconsOut;
+
+   tellFinderGetWindowInfoOut = record
+      recvCount: integer;
+      finderResult: integer;
+      windType: integer;
+      windView: integer;
+      windFST: integer;
+      windTitle: pStringPtr;
+      windPath: gsosInStringPtr;
+      reserved1: longint;
+      reserved2: longint;
+      end;
+   tellFinderGetWindowInfoOutPtr = ^tellFinderGetWindowInfoOut;
+
+   tellFinderRemoveFromExtrasOut = record
+      recvCount: integer;
+      finderResult: integer;
+      end;
+   tellFinderRemoveFromExtrasOutPtr = ^tellFinderRemoveFromExtrasOut;
+
+   tellFinderSpecialPreferencesIn = record
+      pCount: integer;
+      allowDrag: boolean;
+      end;
+   tellFinderSpecialPreferencesInPtr = ^tellFinderSpecialPreferencesIn;
+
+   tellFinderSpecialPreferencesOut = record
+      recvCount: integer;
+      finderResult: integer;
+      end;
+   tellFinderSpecialPreferencesOutPtr = ^tellFinderSpecialPreferencesOut;
+
+implementation
+end.

--- a/Tool.Interface/FontMgr.pas
+++ b/Tool.Interface/FontMgr.pas
@@ -1,0 +1,135 @@
+{$keep 'FontMgr'}
+unit FontMgr;
+interface
+
+{********************************************************
+*
+*   Font Manager Interface File
+*
+*   Other USES Files Needed: Common, QuickDrawII
+*
+*   Other Tool Sets Needed:  Tool Locator, Memory Manager,
+*                            Quick Draw II, Integer Math Tool Set
+*
+*  Copyright 1987-1990
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common, QuickDrawII;
+
+const
+   (* font stat bits *)
+   memBit          =   $0001;          (* font is in memory                   *)
+   unrealBit       =   $0002;          (* font is scaled from another font    *)
+   apFamBit        =   $0004;          (* font family supplied by application *)
+   apVarBit        =   $0008;          (* font added by AddFontVar call or    *)
+                                       (* scaled from such a font             *)
+   purgeBit        =   $0010;          (* font is purgeable                   *)
+   notDiskBit      =   $0020;          (* font not in ROM or in FONTS folder  *)
+   notFoundBit     =   $8000;          (* specified font not found            *)
+
+   (* font spec bits *)
+   memOnlyBit      =   $0001;          (* allow only ROM fonts and fonts     *)
+                                       (* currently in memory                *)
+   realOnlyBit     =   $0002;          (* allow only unscaled fonts          *)
+   anyFamBit       =   $0004;          (* ignore family number in call       *)
+   anyStyleBit     =   $0008;          (* allow any partially matching style *)
+   anySizeBit      =   $0010;          (* ignore point size in call          *)
+
+   (* family stat bits *)
+   notBaseBit      =   $0020;          (* family is not a base family *)
+
+   (* family spec bits *)
+   baseOnlyBit     =   $0020;          (* allow only base families *)
+
+   (* Scale word *)
+   dontScaleBit    =   $0001;          (* disable font scaling *)
+
+   (* Family Numbers *)
+   newYork         =   $0002;
+   geneva          =   $0003;
+   monaco          =   $0004;
+   venice          =   $0005;
+   london          =   $0006;
+   athens          =   $0007;
+   sanFran         =   $0008;
+   toronto         =   $0009;
+   cairo           =   $000B;
+   losAngeles      =   $000C;
+   times           =   $0014;
+   helvetica       =   $0015;
+   courier         =   $0016;
+   symbol          =   $0017;
+   taliesin        =   $0018;
+   shaston         =   $FFFE;
+
+(* Font records are defined in Common and QuickDrawII interface files. *)
+
+
+procedure FMBootInit; tool ($1B, $01); (* WARNING: an application should
+                                                   NEVER make this call *)
+
+procedure FMStartUp (userID, dPageAddr: integer); tool ($1B, $02);
+
+procedure FMShutDown; tool ($1B, $03);
+
+function FMVersion: integer; tool ($1B, $04);
+
+procedure FMReset; tool ($1B, $05);    (* WARNING: an application should
+                                                   NEVER make this call *)
+
+function FMStatus: boolean; tool ($1B, $06);
+
+procedure AddFamily (famNum: integer; namePtr: univ pStringPtr); tool ($1B, $0D);
+
+procedure AddFontVar (theFontHandle: fontHndl; newSpecs: integer);
+tool ($1B, $14);
+
+function ChooseFont (currentID: fontID; famSpecs: integer): longint;
+tool ($1B, $16);
+
+function CountFamilies (famSpecs: integer): integer; tool ($1B, $09);
+
+function CountFonts (desiredID: fontID; specs: integer): integer;
+tool ($1B, $10);
+
+function FamNum2ItemID (familyNum: integer): integer; tool ($1B, $1B);
+
+function FindFamily (famSpecs, positionNum: integer; name: univ pStringPtr):
+                     integer; tool ($1B, $0A);
+
+procedure FindFontStats (desiredID: fontID;  specs, positionNum: integer;
+                         var resultPtr: fontStatRec); tool ($1B, $11);
+
+procedure FixFontMenu (menuID, startingID, famSpecs: integer); tool ($1B, $15);
+
+function FMGetCurFID: longint; tool ($1B, $1A);
+
+function FMGetSysFID: longint; tool ($1B, $19);
+
+procedure FMSetSysFont (theFontID: fontID); tool ($1B, $18);
+
+function GetFamInfo (famNum: integer; name: univ pStringPtr): integer;
+tool ($1B, $0B);
+
+function GetFamNum (name: univ pStringPtr): integer; tool ($1B, $0C);
+
+procedure InstallFont (desiredID: fontID; scaleWord: integer); tool ($1B, $0E);
+
+function InstallWithStats (desiredID: fontID; scaleWord: integer):
+                           fontStatRecPtr; tool ($1B, $1C);
+
+function ItemID2FamNum (itemID: integer): integer; tool ($1B, $17);
+
+procedure LoadFont (desiredID: fontID; specs, positionNum: integer;
+                    var resultPtr: fontStatRec); tool ($1B, $12);
+
+procedure LoadSysFont; tool ($1B, $13);
+
+procedure SetPurgeStat (theFontID: fontID; purgeStat: integer); tool ($1B, $0F);
+
+implementation
+end.

--- a/Tool.Interface/GSOS.pas
+++ b/Tool.Interface/GSOS.pas
@@ -335,8 +335,8 @@ type
       fileType: integer;
       auxType: longint;
       nullField1: integer;       {set this field to zero}
-      createDateTime: longint;
-      modDateTome: longint;
+      createDateTime: timeField;
+      modDateTime: timeField;
       optionList: optionListPtr;
       nullField2: longint;       {set this field to zero}
       nullField3: longint;       {set this field to zero}

--- a/Tool.Interface/GSOS.pas
+++ b/Tool.Interface/GSOS.pas
@@ -1,0 +1,499 @@
+{$keep 'GSOS'}
+unit GSOS;
+interface
+
+{********************************************************
+*
+*  GS/OS Interface File
+*
+*  Other Uses Files Needed: Common
+*
+*  Notes:  Each call refers to a data control block (DCB),
+*          defined as a record.  Calls which return values
+*          store the output into the DCB.
+*          All calls return an error number.
+*
+*  Copyright 1987-1992
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common;
+
+const
+   (* File System IDs *)
+   (* reserved = 0 *)
+   ProDOS_SOS      =   1;
+   DOS_3_3         =   2;
+   DOS_3_2         =   3;
+   ApplePascal     =   4;
+   Macintosh_MFS   =   5;
+   Macintosh_HFS   =   6;
+   LISA            =   7;
+   AppleCPM        =   8;
+   CharacterFST    =   9;
+   MS_DOS          =   10;
+   HighSierra      =   11;
+   ISO_9660        =   12;
+   AppleShare      =   13;
+
+   (* Standard I/O prefixes *)
+   stdIn       =   10;
+   stdOut      =   11;
+   stdError    =   12;
+
+type
+   bindIntOSDCB = record
+      pcount: integer;
+      intNum: integer;
+      vrn: integer;
+      intCode: ptr;
+      end;
+
+   changePathOSDCB = record
+      pcount: integer;
+      pathName: gsosInStringPtr;
+      newPathName: gsosInStringPtr;
+      flags: integer;
+      end;
+
+   closeOSDCB = record
+      pcount: integer;
+      refNum: integer;
+      end;
+
+   clrBkupBitOSDCB = record
+      pcount: integer;
+      pathName: gsosInStringPtr;
+      end;
+
+   createOSDCB = record
+      pcount: integer;
+      pathName: gsosInStringPtr;
+      access: integer;
+      fileType: integer;
+      auxType: longint;
+      storageType: integer;
+      dataEOF: longint;
+      resourceEOF: longint;
+      end;
+
+   destroyOSDCB = record
+      pcount: integer;
+      pathName: gsosInStringPtr;
+      end;
+
+   devReadWriteOSDCB = record
+      pcount: integer;
+      devNum: integer;
+      buffer: ptr;
+      requestCount: longint;
+      startingBlock: longint;
+      blockSize: integer;
+      transferCount: longint;
+      end;
+
+   dInfoOSDCB = record
+      pcount: integer;
+      devNum: integer;
+      devName: gsosOutStringPtr;
+      characteristics: integer;
+      totalBlocks: longint;
+      slotNum: integer;
+      unitNum: integer;
+      version: integer;
+      deviceID: integer;
+      headLink: integer;
+      forwardLink: integer;
+      extendedDIBptr: ptr;
+      end;
+
+   dirEntryOSDCB = record
+      pcount: integer;
+      refNum: integer;
+      flags: integer;
+      base: integer;
+      displacement: integer;
+      name: gsosOutStringPtr;
+      entryNum: integer;
+      fileType: integer;
+      eofValue: longint;
+      blockCount: longint;
+      createDateTime: timeField;
+      modDateTime: timeField;
+      access: integer;
+      auxType: longint;
+      fileSysID: integer;
+      optionList: optionListPtr;
+      resourceEOF: longint;
+      resourceBlocks: longint;
+      end;
+
+   dRenameOSDCB = record
+      pcount: integer;
+      devNum: integer;
+      replaceString: gsosInStringPtr;
+      end;
+
+   dStatusOSDCB = record
+      pcount: integer;
+      devNum: integer;
+      statusCode: integer;
+      statusList: ptr;
+      requestCount: longint;
+      transferCount: longint;
+      end;
+
+   eofOSDCB = record
+      pcount: integer;
+      refNum: integer;
+      eofEOF: longint;
+      end;
+
+   expandPathOSDCB = record
+      pcount: integer;
+      inputPath: gsosInStringPtr;
+      outputPath: gsosOutStringPtr;
+      flags: integer;
+      end;
+
+   flushOSDCB = record
+      pcount: integer;
+      refNum: integer;
+      end;
+
+   formatOSDCB = record
+      pcount: integer;
+      devName: gsosInStringPtr;
+      volName: gsosInStringPtr;
+      fileSysID: integer;
+      reqFileSysID: integer;
+      flags: integer;
+      reaVolName: gsosOutStringPtr;
+      end;
+
+   fstInfoOSDCB = record
+      pcount: integer;
+      fstNum: integer;
+      fileSysID: integer;
+      fstName: gsosOutStringPtr;
+      version: integer;
+      attributes: integer;
+      blockSize: integer;
+      maxVolSize: longint;
+      maxFileSize: longint;
+      end;
+
+   getDevNumOSDCB = record
+      pcount: integer;
+      devName: gsosInStringPtr;
+      devNum: integer;
+      end;
+
+   getFileInfoOSDCB = record
+      pcount: integer;
+      pathName: gsosInStringPtr;
+      access: integer;
+      fileType: integer;
+      auxType: longint;
+      storageType: integer;
+      createDateTime: timeField;
+      modDateTime: timeField;
+      optionList: optionListPtr;
+      dataEOF: longint;
+      blocksUsed: longint;
+      resourceEOF: longint;
+      resourceBlocks: longint;
+      end;
+
+   getMarkOSDCB = record
+      pcount: integer;
+      refNum: integer;
+      position: longint;
+      end;
+
+   getNameOSDCB = record
+      pcount: integer;
+      dataBuffer: gsosOutStringPtr;
+      userID: integer;
+      end;
+
+   getPrefixOSDCB = record
+      pcount: integer;
+      prefixNum: integer;
+      prefix: gsosOutStringPtr;
+      end;
+
+   getRefInfoOSDCB = record
+      pcount: integer;
+      referenceNumber: integer;
+      access: integer;
+      thePath: gsosOutStringPtr;
+      resourceNumber: integer;
+      level: integer;
+      end;
+
+   getRefNumOSDCB = record
+      pcount: integer;
+      thePath: gsosInStringPtr;
+      referenceNumber: integer;
+      access: integer;
+      resourceNum: integer;
+      caseSense: integer;
+      displacement: integer;
+      end;
+
+   getStdRefNumOSDCB = record
+      pcount: integer;
+      prefixNumber: integer;
+      referenceNumber: integer;
+      end;
+
+   judgeNameOSDCB = record
+      pcount: integer;
+      fileSysID: integer;
+      nameType: integer;
+      syntax: pStringPtr;
+      maxLen: integer;
+      name: gsosOutStringPtr;
+      nameFlags: integer;
+      end;
+
+   levelOSDCB = record
+      pcount: integer;
+      level: integer;
+      levelMode: integer;
+      end;
+
+   newlineOSDCB = record
+      pcount: integer;
+      refNum: integer;
+      enableMask: integer;
+      numChars: integer;
+      newlineTable: ptr;
+      end;
+
+   notifyOSDCB = record
+      pcount: integer;
+      theProc: procPtr;
+      end;
+
+   nullOSDCB = record
+      pcount: integer;
+      end;
+
+   openOSDCB = record
+      pcount: integer;
+      refNum: integer;
+      pathName: gsosInStringPtr;
+      requestAccess: integer;
+      resourceNumber: integer;
+      access: integer;
+      fileType: integer;
+      auxType: longint;
+      storageType: integer;
+      createDateTime: timeField;
+      modDateTime: timeField;
+      optionList: optionListPtr;
+      dataEOF: longint;
+      blocksUsed: longint;
+      resourceEOF: longint;
+      resourceBlocks: longint;
+      end;
+
+   osVersionOSDCB = record
+      pcount: integer;
+      version: integer;
+      end;
+
+   prefsOSDCB = record
+      pcount: integer;
+      preferences: integer;
+      end;
+
+   quitOSDCB = record
+      pcount: integer;
+      pathName: gsosInStringPtr;
+      flags: integer;
+      end;
+
+   readWriteOSDCB = record
+      pcount: integer;
+      refNum: integer;
+      dataBuffer: ptr;
+      requestCount: longint;
+      transferCount: longint;
+      cachePriority: integer;
+      end;
+
+   setFileInfoOSDCB = record
+      pcount: integer;
+      pathName: gsosInStringPtr;
+      access: integer;
+      fileType: integer;
+      auxType: longint;
+      nullField1: integer;       {set this field to zero}
+      createDateTime: longint;
+      modDateTome: longint;
+      optionList: optionListPtr;
+      nullField2: longint;       {set this field to zero}
+      nullField3: longint;       {set this field to zero}
+      nullField4: longint;       {set this field to zero}
+      nullField5: longint;       {set this field to zero}
+      end;
+
+   setMarkOSDCB = record
+      pcount: integer;
+      refNum: integer;
+      base: integer;
+      displacement: longint;
+      end;
+
+   setStdRefNumOSDCB = record
+      pcount: integer;
+      prefixNum: integer;
+      refNum: integer;
+      end;
+
+   shutdownOSDCB = record
+      pcount: integer;
+      shutdownFlag: integer;
+      end;
+
+   statusOSDCB = record
+      pcount: integer;
+      status: integer;
+      end;
+
+   unbindIntOSDCB = record
+      pcount: integer;
+      intNum: integer;
+      end;
+
+   volumeOSDCB = record
+      pcount: integer;
+      devName: gsosInStringPtr;
+      volName: gsosOutStringPtr;
+      totalBlocks: longint;
+      freeBlocks: longint;
+      fileSysID: integer;
+      blockSize: integer;
+      characteristics: integer;
+      deviceID: integer;
+      end;
+
+
+procedure AddNotifyProcGS (var parms: notifyOSDCB); prodos ($2034);
+
+procedure BeginSessionGS (var parms: nullOSDCB); prodos ($201D);
+
+procedure BindIntGS (var parms: bindIntOSDCB); prodos ($2031);
+
+procedure ChangePathGS (var parms: changePathOSDCB); prodos ($2004);
+
+procedure ClearBackupGS (var parms: clrBkupBitOSDCB); prodos ($200B);
+
+procedure CloseGS (var parms: closeOSDCB); prodos ($2014);
+
+procedure CreateGS (var parms: createOSDCB); prodos ($2001);
+
+procedure DControlGS (var parms: dStatusOSDCB); prodos ($202E);
+
+procedure DelNotifyProcGS (var parms: notifyOSDCB); prodos ($2035);
+
+procedure DestroyGS (var parms: destroyOSDCB); prodos ($2002);
+
+procedure DInfoGS (var parms: dInfoOSDCB); prodos ($202C);
+
+procedure DReadGS (var parms: devReadWriteOSDCB); prodos ($202F);
+
+procedure DRenameGS (var parms: dRenameOSDCB); prodos ($2036);
+
+procedure DStatusGS (var parms: dStatusOSDCB); prodos ($202D);
+
+procedure DWriteGS (var parms: devReadWriteOSDCB); prodos ($2030);
+
+procedure EndSessionGS (var parms: nullOSDCB); prodos ($201E);
+
+procedure EraseDiskGS (var parms: formatOSDCB); prodos ($2025);
+
+procedure ExpandPathGS (var parms: expandPathOSDCB); prodos ($200E);
+
+procedure FlushGS (var parms: flushOSDCB); prodos ($2015);
+
+procedure FormatGS (var parms: formatOSDCB); prodos ($2024);
+
+procedure GetBootVolGS (var parms: getNameOSDCB); prodos ($2028);
+
+procedure GetDevNumberGS (var parms: getDevNumOSDCB); prodos ($2020);
+
+procedure GetDirEntryGS (var parms: dirEntryOSDCB); prodos ($201C);
+
+procedure GetEOFGS (var parms: eofOSDCB); prodos ($2019);
+
+procedure GetFileInfoGS (var parms: getFileInfoOSDCB); prodos ($2006);
+
+procedure GetFSTInfoGS (var parms: fstInfoOSDCB); prodos ($202B);
+
+procedure GetLevelGS (var parms: levelOSDCB); prodos ($201B);
+
+procedure GetMarkGS (var parms: getMarkOSDCB); prodos ($2017);
+
+procedure GetNameGS (var parms: getNameOSDCB); prodos ($2027);
+
+procedure GetPrefixGS (var parms: getPrefixOSDCB); prodos ($200A);
+
+procedure GetRefInfoGS (var parms: getRefInfoOSDCB); prodos ($2039);
+
+procedure GetRefNumGS (var parms: getRefNumOSDCB); prodos ($2038);
+
+procedure GetStdRefNumGS (var parms: getStdRefNumOSDCB); prodos ($2037);
+
+procedure GetSysPrefsGS (var parms: prefsOSDCB); prodos ($200F);
+
+procedure GetVersionGS (var parms: osVersionOSDCB); prodos ($202A);
+
+procedure JudgeNameGS (var parms: judgeNameOSDCB); prodos ($2007);
+          
+procedure NewlineGS (var parms: newlineOSDCB); prodos ($2011);
+
+procedure NullGS (var parms: nullOSDCB); prodos ($200D);
+
+procedure OpenGS (var parms: openOSDCB); prodos ($2010);
+
+procedure OSShutdownGS (var parms: shutdownOSDCB); prodos ($2003);
+
+procedure QuitGS (var parms: quitOSDCB); prodos ($2029);
+
+procedure ReadGS (var parms: readWriteOSDCB); prodos ($2012);
+
+procedure ResetCacheGS (var parms: nullOSDCB); prodos ($2026);
+
+procedure SessionStatusGS (var parms: statusOSDCB); prodos ($201F);
+
+procedure SetEOFGS (var parms: setMarkOSDCB); prodos ($2018);
+
+procedure SetFileInfoGS (var parms: setFileInfoOSDCB); prodos ($2005);
+
+procedure SetLevelGS (var parms: levelOSDCB); prodos ($201A);
+
+procedure SetMarkGS (var parms: setMarkOSDCB); prodos ($2016);
+
+procedure SetPrefixGS (var parms: getPrefixOSDCB); prodos ($2009);
+
+procedure SetStdRefNum (var parms: setStdRefNumOSDCB); prodos ($203A);
+
+procedure SetSysPrefsGS (var parms: prefsOSDCB); prodos ($200C);
+
+procedure UnbindIntGS (var parms: unbindIntOSDCB); prodos ($2032);
+
+procedure VolumeGS (var parms: volumeOSDCB); prodos ($2008);
+
+procedure WriteGS (var parms: readWriteOSDCB); prodos ($2013);
+
+
+implementation
+
+end.

--- a/Tool.Interface/HyperStudio.pas
+++ b/Tool.Interface/HyperStudio.pas
@@ -1,0 +1,225 @@
+(****************************************************************
+*
+*  Interface for HyperStudio
+*
+*  Other USES Files Needed: - None -
+*
+*  February 1993
+*  Mike Westerfield
+*
+*  Thanks to Ken Kashmarek, who supplied the original files from
+*  wich I shamelessly swiped the names used here.  (Of course,
+*  that made it easier for him to convert his software!)
+*
+*  Copyright 1993
+*  Byte Works, Inc.
+*
+****************************************************************)
+
+{$keep 'HyperStudio'}
+
+unit HyperStudio;
+
+interface
+
+uses Common;
+
+const
+					{Callback numbers}
+   cMoveToFirst = 1;
+   cMoveToLast = 2;
+   cMovePrev = 3;
+   cMoveNext = 4;
+   cMoveToID = 5;
+   cRedrawCard = 6;
+   cGetStackName = 7;
+   cFindText = 8;
+   cPokeyFlag = 9;
+   cDoMenu = 10;
+   cGetHSMode = 11;
+   cGetHSVersion = 12;
+   cGetStackPathName = 13;
+   cGetNumCards = 14;
+   cGetNumButtons = 15;
+   cGetNumFields = 16;
+   cGetNumGraphics = 17;
+   cPoint2StackHead = 18;
+   cPoint2FirstCard = 19;
+   cPoint2CurrCard = 20;
+   cPoint2NextCard = 21;
+   cPoint2CardItems = 22;
+   cPoint2NextCdItem = 23;
+   cPoint2StackItem = 24;
+   cGetCallerAddr = 25;
+   cHideStackItem = 26;
+   cShowStackItem = 27;
+   cLockItem = 28;
+   cUnLockItem = 29;
+   cDeleteStackItem = 30;
+   cGetItemRect = 31;
+   cSetItemRect = 32;
+   cGetButtonIcon = 33;
+   cSetButtonIcon = 34;
+   cGetItemStats = 35;
+   cLaunchApplication = 36;
+   cGetItemLoc = 37;
+   cRedrawItem = 38;
+   cMouseClick = 39;
+   cGetHSCursorAdr = 40;
+   cPassText = 41;
+   cGetClickLoc = 42;
+   cExecuteButton = 43;
+   cScrollField = 44;
+   cSetHSFont = 45;
+   cSetBrushNum = 46;
+   cSetLineWidth = 47;
+   cGetOffScreen = 48;
+   cGetCurrentScore = 49;
+   cSetNextTransition = 50;
+   cIsMenuThere = 51;
+   cGetUndoBuffer = 52;
+   cGetCardPalette = 53;
+   cPlayDiskSound = 54;
+   cPlayResSound = 55;
+   cGetSelectedInfo = 56;
+   cGetPatterns = 57;
+   cGetFieldText = 58;
+   cSetFieldText = 59;
+   cGetHSFont = 60;
+   cLoadPaintFile = 61;
+   cSwapCardPos = 62;
+   cSortCards = 63;
+   cSetDirtyFlag = 64;
+   cAddScript2Button = 65;
+   cCreatePaletteWindow = 66;
+   cCallNBA = 67;
+   cCallHS_XCMD = 68;
+   cGetResRefNums = 69;
+   cSetBkgdDirty = 70;
+   cPlaySound = 71;
+   cGetAdvancedUser = 72;
+   cVideoOn = 73;
+   cVideoOff = 74;
+   cMakeTransMask = 75;
+   cInitTrans = 76;
+   cIncTrans = 77;
+   cHorizStrip = 78;
+   cVertStrip = 79;
+   cBrushDialog = 80;
+   cLineDialog = 81;
+   cPatternDialog = 82;
+   cColorDialog = 83;
+   cStartDrawing = 84;
+   cDrawToScreen = 85;
+   cDrawToOffScreen = 86;
+   cEndDrawing = 87;
+   cSetDrawColor = 88;
+   cGetNewBtnName = 89;
+   cGetSndStatus = 90;
+   cSetMarkedCard = 91;
+   cGetNewExtrasMenu = 92;
+   cGetOtherCursors = 93;
+   cDoButtonAnimation = 94;
+   cPlayAnimation = 95;
+   cFlush2Undo = 96;
+   cLoadStackField = 97;
+   cSaveStackField = 98;
+   cPrintStackField = 99;
+   cLoadText = 100;
+   cSaveText = 101;
+   cPrintText = 102;
+   cGetPaintVars = 103;
+   cGetItemHandle = 104;
+   cBeginXSound = 105;
+   cEndXSound = 106;
+   cGetColorCtlDefProc = 107;
+
+   mAboutHyperStudio = 0;
+   mPreferences = 1;
+   mNewStack = 2;
+   mOpenStack = 3;
+   mSaveStack = 4;
+   mSaveStackAs = 5;
+   mLoadBackground = 6;
+   mSaveBackground = 7;
+   mAddClipArt = 8;
+   mPageSetup = 9;
+   mPrint = 10;
+   mQuit = 11;
+   mUndo = 12;
+   mCut = 13;
+   mCopy = 14;
+   mPaste = 15;
+   mClear = 16;
+   mNewCard = 17;
+   mDeleteCard = 18;
+   mCutCard = 19;
+   mCopyCard = 20;
+   mFlipHorizontal = 21;
+   mFlipVertical = 22;
+   mEraseBackground = 23;
+   mBack = 24;
+   mHome = 25;
+   mFirstCard = 26;
+   mPreviousCard = 27;
+   mNextCard = 28;
+   mLastCard = 29;
+   mMoveToCard = 30;
+   mFindText = 31;
+   mSetCurrentTool = 32;
+   mItemInfo = 33;
+   mCardInfo = 34;
+   mBackgroundInfo = 35;
+   mStackInfo = 36;
+   mBringCloser = 37;
+   mSendFarther = 38;
+   mAddButton = 39;
+   mAddGraphic = 40;
+   mAddField = 41;
+   mAddVideo = 42;
+   mSetCurrentColor = 43;
+   mLineSizedialog = 44;
+   mBrushShapedialog = 45;
+   mToggleDrawFilled = 46;
+   mToggleDrawMultiple = 47;
+   mToggleDrawCentered = 48;
+   mTextStyledialog = 49;
+   mTextColordialog = 50;
+   mBackgroundColordialog = 51;
+   mReplaceColorsdialog = 52;
+   mEditPattern = 53;
+   mStandardPaletteRestore = 54;
+   mHideItems = 55;
+   mToggleMenubarVisibility = 56;
+      
+type
+   wString = record			{word string}
+      length: integer;
+      str: packed array[1..256] of char;
+      end;
+   wStringPtr = ^wString;
+
+   HSParams = record			{HyperStudio Parameters}
+      ButtonID: integer;
+      CardID: integer;
+      ScriptHand: handle;
+      ScriptLength: longint;
+      TextPassedPtr: wStringPtr;
+      CallBack: ptr;
+      Version: integer;
+      MemoryID: integer;
+      Command: integer;
+      SubCommand: integer;
+      CP1: longint;
+      CP2: longint;
+      CP3: longint;
+      CP4: longint;
+      CP5: longint;
+      end;
+   HSParamPtr = ^HSParams;
+
+procedure __NBACallBack (call: integer; parm: HSParamPtr); extern;
+
+implementation
+
+end.

--- a/Tool.Interface/HyperXCMD.pas
+++ b/Tool.Interface/HyperXCMD.pas
@@ -1,0 +1,259 @@
+(*********************************************************
+*
+* Definition file for HyperCard XCMDs and XFCNs in Pascal
+* For use with HyperCard IIGS Version 1.1
+*
+* Other USES Files Needed: Common
+*
+* Copyright Apple Computer, Inc. 1990-91
+* All Rights Reserved
+*
+* Copyright 1993, Byte Works, Inc.
+*
+*********************************************************)
+
+{$keep 'HyperXCMD'}
+
+unit HyperXCMD;
+
+interface
+
+uses Common;
+
+const
+   _CallBackVector = $E10220;		{HyperCard call entry point}
+
+					{XCMDBlock constants for event.what...}
+   xOpenEvt = 1000;                     {the first event after you are created}
+   xCloseEvt = 1001;                    {your window is being forced close}
+   xHidePalettesEvt = 1004;             {someone called HideHCPalettes}
+   xShowPalettesEvt = 1005;             {someone called ShowHCPalettes}
+   xCursorWithin = 1300;                {cursor is within the window}
+
+					{XWindow styles}
+   xWindoidStyle = 0;
+   xRectStyle = 1;
+   xShadowStyle = 2;
+   xDialogStyle = 3;
+
+type
+   str19 = string[19];
+   string19Ptr = ^str19;
+   string19Handle = ^string19Ptr;
+   str31 = string[31];
+   string31Ptr = ^str31;
+   string31Handle = ^string31Ptr;
+
+   XWEventInfo = record
+      eventWindow: grafPortPtr;
+      event: eventRecord;
+      eventParams: array[1..9] of longint;
+      eventResult: handle;
+      end;
+   XWEventInfoPtr = ^XWEventInfo;
+
+   XCMDBlock = record
+      paramCount: integer;
+      params: array[1..16] of handle;
+      returnValue: handle;
+      passFlag: boolean;
+      userID: integer;
+      returnStat: integer;              {0 if normal, 1 if error}
+      end;
+   XCMDPtr = ^XCMDBlock;
+
+   gsosInStringHandle = ^gsosInStringPtr;
+
+(****  HyperTalk Utilities  ****)
+function EvalExpr (expr: pString): handle; vector(_CallBackVector, $0002);
+
+procedure SendCardMessage (msg: pString); vector(_CallBackVector, $0001);
+
+procedure SendHCMessage (msg: pString); vector(_CallBackVector, $0005);
+
+
+(****  Memory Utilities  ****)
+function GetGlobal (globName: pString): handle; vector(_CallBackVector, $0012);
+
+procedure SetGlobal (globName: pString; globValue: handle);
+                     vector(_CallBackVector, $0013);
+
+procedure ZeroBytes (dstPtr: ptr; longCount: Longint);
+                     vector(_CallBackVector, $0006);
+
+
+(****  String Utilities  ****)
+function GSStringEqual (src1: gsosInStringHandle; src2: gsosInStringHandle): boolean;
+                        vector(_CallBackVector, $0022);
+
+procedure ScanToReturn (var scanPtr: ptr); vector(_CallBackVector, $001C);
+
+procedure ScanToZero (var scanPtr: ptr); vector(_CallBackVector, $001D);
+
+function StringEqual (str1: pString; str2: pString): boolean;
+                      vector(_CallBackVector, $001A);
+
+function StringLength (strPtr: ptr): longint; vector(_CallBackVector, $0003);
+
+function StringMatch (stringPattern: pString; target: ptr): ptr;
+                      vector(_CallBackVector, $0004);
+
+
+(****  String Conversions  ****)
+{ Standard Pascal does not allow returning strings.
+function BoolToStr (bool: boolean): str31; vector(_CallBackVector, $0010);
+}
+
+function CopyGSString (src: gsosInStringHandle): gsosInStringHandle;
+                       vector(_CallBackVector, $0020);
+
+function GSConcat (src1: gsosInStringHandle; src2: gsosInStringHandle):
+                   gsosInStringHandle;
+                   vector(_CallBackVector, $0021);
+
+{ Standard Pascal does not allow returning strings.
+function ExtToStr (extendedNumber: Extended): str31;
+                   vector(_CallBackVector, $0011);
+}
+
+{ Standard Pascal does not allow returning strings.
+function GSToPString (src: gsosInStringHandle): pString;
+                      vector(_CallBackVector, $001E);
+}
+ 
+function GSToZero (src: gsosInStringHandle): handle;
+                   vector(_CallBackVector, $0023);
+
+{ Standard Pascal does not allow returning strings.
+function LongToStr (posNum: longint): str31; vector(_CallBackVector, $000D);
+}
+
+{ Standard Pascal does not allow returning strings.
+function NumToHex (longNumber: longint; nDigits: integer): Str19;
+                   vector(_CallBackVector, $000F);
+}
+
+{ Standard Pascal does not allow returning strings.
+function NumToStr (longNumber: longint): str31; vector(_CallBackVector, $000E);
+}
+
+function PasToZero (str: pString): handle; vector(_CallBackVector, $0007);
+
+procedure PointToStr (pt: Point; var str: pString);
+                      vector(_CallBackVector, $002D);
+
+function PToGSString (src: pString): gsosInStringHandle;
+                      vector(_CallBackVector, $001F);
+
+procedure RectToStr (rct: Rect; var str: pString);
+                     vector(_CallBackVector, $002E);
+
+procedure ReturnToPas (zeroStr: ptr; var pasStr: pString);
+                       vector(_CallBackVector, $001B);
+
+function StrToBool (str: str31): boolean; vector(_CallBackVector, $000B);
+
+function StrToExt (str: str31): Extended; vector(_CallBackVector, $000C);
+
+function StrToLong (str: str31): longint; vector(_CallBackVector, $0009);
+
+function StrToNum (str: str31): longint; vector(_CallBackVector, $000A);
+
+procedure StrToPoint (str: pString; var pt: Point);
+                      vector(_CallBackVector, $002F);
+
+procedure StrToRect (str: pString; var rct: Rect);
+                     vector(_CallBackVector, $0030);
+
+function ZeroToGS (src: handle): gsosInStringHandle;
+                   vector(_CallBackVector, $0024);
+
+procedure ZeroToPas (zeroStr: ptr; var pasStr: pString);
+                     vector(_CallBackVector, $0008);
+
+
+(****  Field Utilities  ****)
+function GetFieldByID (cardFieldFlag: boolean; fieldID: integer): handle;
+                       vector(_CallBackVector, $0016);
+
+function GetFieldByName (cardFieldFlag: boolean; fieldName: pString): handle;
+                         vector(_CallBackVector, $0014);
+
+function GetFieldByNum (cardFieldFlag: boolean; fieldNum: integer): handle;
+                        vector(_CallBackVector, $0015);
+
+procedure SetFieldByID (cardFieldFlag: boolean; fieldID: integer;
+                        fieldVal: handle);
+                        vector(_CallBackVector, $0019);
+
+procedure SetFieldByName (cardFieldFlag: boolean; fieldNName: pString;
+                          fieldVal: handle);
+                          vector(_CallBackVector, $0017);
+
+procedure SetFieldByNum (cardFieldFlag: boolean; fieldNum: integer;
+                         fieldVal: handle);
+                         vector(_CallBackVector, $0018);
+
+(****  Graphic Utilities  ****)
+procedure ChangedMaskAndData (whatChanged: integer);
+                              vector(_CallBackVector, $002C);
+
+procedure GetMaskAndData (var mask: LocInfo; var data: LocInfo);
+                          vector(_CallBackVector, $002B);
+
+
+(****  Miscellaneous Utilities  ****)
+procedure BeginXSound; vector(_CallBackVector, $0029);
+
+procedure EndXSound; vector(_CallBackVector, $002A);
+
+
+(****  Resource Names Utilities  ****)
+function FindNamedResource (resourceType: integer; resourceName: pString;
+                            var theFile: integer; var resourceID: longint):
+                            boolean;
+                            vector(_CallBackVector, $0026);
+
+{ Standard Pascal does not allow returning strings.
+function GetResourceName (resourceType: integer; resourceID: longint): pString;
+                          vector(_CallBackVector, $0028);
+}
+
+function LoadNamedResource (resourceType: integer; resourceName: pString):
+                            handle;
+                            vector(_CallBackVector, $0025);
+
+procedure SetResourceName (resourceType: integer; resourceID: longint;
+                           resourceName: pString);
+                           vector(_CallBackVector, $0027);
+
+
+(****  Creating and Disposing XWindoids  ****)
+function NewXWindow (boundsRect: Rect; title: str31; visible: boolean;
+                     windowStyle: integer): grafPortPtr;
+                     vector(_CallBackVector, $0031);
+
+procedure CloseXWindow (window: grafPortPtr); vector(_CallBackVector, $0033);
+
+
+(****  XWindoid Utilities  ****)
+function GetXWindowValue (window: grafPortPtr): longint;
+                          vector(_CallBackVector, $0037);
+
+procedure HideHCPalettes; vector(_CallBackVector, $0034);
+
+procedure ShowHCPalettes; vector(_CallBackVector, $0035);
+
+procedure SetXWIdleTime (window: grafPortPtr; interval: longint);
+                         vector(_CallBackVector, $0032);
+
+procedure SetXWindowValue (window: grafPortPtr; customValue: longint);
+                           vector(_CallBackVector, $0036);
+
+procedure XWAllowReEntrancy (window: grafPortPtr; allowSysEvts: boolean;
+                             allowHCEvts: boolean);
+                             vector(_CallBackVector, $0038);
+
+implementation
+
+end.

--- a/Tool.Interface/IntegerMath.pas
+++ b/Tool.Interface/IntegerMath.pas
@@ -1,0 +1,143 @@
+{$keep 'IntegerMath'}
+unit IntegerMath;
+interface
+
+{********************************************************
+*
+*  Integer Math Tool Interface File
+*
+*  Other USES Files Needed: Common
+*
+*  Other Tool Sets Needed:  Tool Locator, Memory Manager
+*
+*  Copyright 1987-1990
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common;
+
+const
+   (* Limits *)
+   minLongint  =   $80000000;      (* min negative signed longint             *)
+   minFrac     =   $80000000;      (* pinned value for neg Frac overflow      *)
+   minFixed    =   $80000000;      (* pinned value for neg Fixed overflow     *)
+   minInt      =   $8000;          (* min negative signed integer             *)
+   maxUInt     =   $FFFF;          (* max positive unsigned integer           *)
+   maxLongint  =   $7FFFFFFF;      (* max positive signed longint             *)
+   maxFrac     =   $7FFFFFFF;      (* pinned value for positive Frac overflow *)
+   maxFixed    =   $7FFFFFFF;      (* pinned value, positive Fixed overflow   *)
+   maxULong    =   $FFFFFFFF;      (* max unsigned longint                    *)
+
+   (* Signed Flag *)
+   unsignedFlag =  $0000;          (* value is not signed *)
+   signedFlag  =   $0001;          (* value is signed     *)
+
+type
+   extendedValue = array [0..9] of byte;
+   extendedValuePtr = ^extendedValue;
+
+
+procedure IMBootInit; tool ($0B, $01);     (* WARNING: an application should
+                                                       NEVER make this call *)
+
+procedure IMStartUp; tool ($0B, $02);
+
+procedure IMShutDown; tool ($0B, $03);
+
+function IMVersion: integer; tool ($0B, $04);
+
+procedure IMReset; tool ($0B, $05);    (* WARNING: an application should
+                                                   NEVER make this call *)
+
+function IMStatus: boolean; tool ($0B, $06);
+
+function Dec2Int (inputStr: univ cStringPtr; strLength, signedFlag: integer):
+                  integer; tool ($0B, $28);
+
+function Dec2Long (inputStr: univ cStringPtr; strLength, signedFlag: integer):
+                   longint; tool ($0B, $29);
+
+function Fix2Frac (fixedValue: longint): longint; tool ($0B, $1C);
+
+function Fix2Long (fixedValue: longint): longint; tool ($0B, $1B);
+
+procedure Fix2X (fixedValue: longint; var extendedVal: extendedValue);
+tool ($0B, $1E);
+
+function FixATan2 (input1, input2: longint): longint; tool ($0B, $17);
+
+function FixDiv (dividend, divisor: longint): longint; tool ($0B, $11);
+
+function FixMul (multiplicand, multiplier: longint): longint; tool ($0B, $0F);
+
+function FixRatio (numerator, denominator: integer): longint; tool ($0B, $0E);
+
+function FixRound (fixedValue: longint): integer; tool ($0B, $13);
+
+function Frac2Fix (fracValue: longint): longint; tool ($0B, $1D);
+
+procedure Frac2X (fracValue: longint; var extendedVal: extendedValue);
+tool ($0B, $1F);
+
+function FracCos (angle: longint): longint; tool ($0B, $15);
+
+function FracDiv (dividend, divisor: longint): longint; tool ($0B, $12);
+
+function FracMul (multiplicand, multiplier: longint): longint; tool ($0B, $10);
+
+function FracSin (angle: longint): longint; tool ($0B, $16);
+
+function FracSqrt (fracValue: longint): longint; tool ($0B, $14);
+
+function Hex2Int (inputStr: univ cStringPtr; strLength: integer): integer;
+tool ($0B, $24);
+
+function Hex2Long (inputStr: univ cStringPtr; strLength: integer): longint;
+tool ($0B, $25);
+
+function HexIt (value: integer): longint; tool ($0B, $2A);
+
+function HiWord (longValue: longint): integer; tool ($0B, $18);
+
+procedure Int2Dec (value: integer; outputStr: univ cStringPtr;
+                   strLength: integer; signedFlag: boolean); tool ($0B, $26);
+
+procedure Int2Hex (value: integer; outputStr: univ cStringPtr;
+                   strLength: integer); tool ($0B, $22);
+
+procedure Long2Dec (value: longint; outputStr: univ cStringPtr;
+                    strLength: integer; signedFlag: boolean); tool ($0B, $27);
+
+function Long2Fix (longValue: longint): longint; tool ($0B, $1A);
+
+procedure Long2Hex (value: longint; outputStr: univ cStringPtr;
+                    strLength: integer); tool ($0B, $23);
+
+(*          ACTUALLY RETURNS 2 LONG WORDS: REMAINDER AND QUOTIENT
+function LongDivide (dividend, divisor: longint): 2 longints; tool ($0B, $0D);
+*)
+
+(*          ACTUALLY RETURNS 2 LONG WORDS: MSB AND LSB
+function LongMul (multiplicand, multiplier: longint): 2 longints;
+tool ($0B, $0C);
+*)
+
+function LoWord (longValue: longint): integer; tool ($0B, $19);
+
+function Multiply (multiplicand, multiplier: integer): longint; tool ($0B, $09);
+
+(* SDivide returns 2 words: the lo word = quotient; hi word = remainder *)
+function SDivide (dividend, divisor: integer): longint; tool ($0B, $0A);
+
+(* UDivide returns 2 words: the lo word = quotient; hi word = remainder *)
+function UDivide (dividend, divisor: integer): longint; tool ($0B, $0B);
+
+function X2Fix (var extendedVal: extendedValue): longint; tool ($0B, $20);
+
+function X2Frac (var extendedVal: extendedValue): longint; tool ($0B, $21);
+
+implementation
+end.

--- a/Tool.Interface/LineEdit.pas
+++ b/Tool.Interface/LineEdit.pas
@@ -1,0 +1,147 @@
+{$keep 'LineEdit'}
+unit LineEdit;
+interface
+
+{********************************************************
+*
+*   Line Edit Tool Set Interface File
+*
+*   Other USES Files Needed: Common
+*
+*   Other Tool Sets Needed:  Tool Locator, Memory Manager,
+*                            Quick Draw II, Event Manager
+*
+*  Copyright 1987-1990, 1993
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common;
+
+const
+   (* Justification *)
+   leJustLeft      =   $0000;      (* left justify       *)
+   leJustCenter    =   $0001;      (* center             *)
+   leJustRight     =   $FFFF;      (* right justify      *)
+   leJustFill      =   $0002;      (* fill justification *)
+
+   (* LEClassifyKey result values *)
+   leKeyIsSpecial    = $8000;
+   leKeyIsNumber     = $4000;
+   leKeyIsHex        = $2000;
+   leKeyIsAlpha      = $1000;
+   leKeyIsNonControl = $0800;
+
+type
+   leRec = record
+       leLineHandle: ^cStringPtr;
+       leLength:     integer;
+       leMaxLength:  integer;
+       leDestRect:   rect;
+       leViewRect:   rect;
+       lePort:       grafPortPtr;
+       leLineHite:   integer;
+       leBaseHite:   integer;
+       leSelStart:   integer;
+       leSelEnd:     integer;
+       leActFlag:    integer;
+       leCarAct:     integer;
+       leCarOn:      integer;
+       leCarTime:    longint;
+       leHiliteHook: procPtr;
+       leCaretHook:  procPtr;
+       leJust:       integer;
+       lePWChar:     integer;
+       end;
+   leRecPtr = ^leRec;
+   leRecHndl = ^leRecPtr;
+
+
+procedure LEBootInit; tool ($14, $01); (* WARNING: an application should
+                                                   NEVER make this call *)
+
+procedure LEStartUp (userID, dPageAddr: integer); tool ($14, $02);
+
+procedure LEShutDown; tool ($14, $03);
+
+function LEVersion: integer; tool ($14, $04);
+
+procedure LEReset; tool ($14, $05);    (* WARNING: an application should
+                                                   NEVER make this call *)
+
+function LEStatus: boolean; tool ($14, $06);
+
+function GetLeDefProc: procPtr; tool ($14, $24);
+
+procedure LEActivate (LEHandle: leRecHndl); tool ($14, $0F);
+
+procedure LEClick (var theEvent: eventRecord; LEHandle: leRecHndl);
+tool ($14, $0D);
+
+procedure LECopy (LEHandle: leRecHndl); tool ($14, $13);
+
+procedure LECut (LEHandle: leRecHndl); tool ($14, $12);
+
+procedure LEDeactivate (LEHandle: leRecHndl); tool ($14, $10);
+
+procedure LEDelete (LEHandle: leRecHndl); tool ($14, $15);
+
+procedure LEDispose (LEHandle: leRecHndl); tool ($14, $0A);
+
+procedure LEFromScrap; tool ($14, $19);
+
+function LEGetScrapLen: integer; tool ($14, $1C);
+
+function LEGetTextHand (LEHandle: leRecHndl): handle; tool ($14, $22);
+
+function LEGetTextLen (LEHandle: leRecHndl): integer; tool ($14, $23);
+
+procedure LEIdle (LEHandle: leRecHndl); tool ($14, $0C);
+
+procedure LEInsert (theText: univ cStringPtr; textLength: integer;
+                    LEHandle: leRecHndl); tool ($14, $16);
+
+procedure LEKey (key, modifiers: integer; LEHandle: leRecHndl);
+tool ($14, $11);
+
+function LENew (var destRect, viewRect: rect; maxTextLen: integer): leRecHndl;
+tool ($14, $09);
+
+procedure LEPaste (LEHandle: leRecHndl); tool ($14, $14);
+
+function LEScrapHandle: handle; tool ($14, $1B);
+
+procedure LESetCaret (caretProc: procPtr; LEHandle: leRecHndl);
+tool ($14, $1F);
+
+procedure LESetHilite (hiliteProc: procPtr; LEHandle: leRecHndl);
+tool ($14, $1E);
+
+procedure LESetJust (just: integer; LEHandle: leRecHndl); tool ($14, $21);
+
+procedure LESetScrapLen (newLength: integer); tool ($14, $1D);
+
+procedure LESetSelect (selStart, selEnd: integer; LEHandle: leRecHndl);
+tool ($14, $0E);
+
+procedure LESetText (theText: univ cStringPtr; textLength: integer;
+                     LEHandle: leRecHndl); tool ($14, $0B);
+
+procedure LETextBox (theText: univ cStringPtr; textLength: integer;
+                     var box: rect; just: integer); tool ($14, $18);
+
+procedure LETextBox2 (theText: univ cStringPtr; textLength: integer;
+                      var box: rect; just: integer); tool ($14, $20);
+
+procedure LEToScrap; tool ($14, $1A);
+
+procedure LEUpdate (LEHandle: leRecHndl); tool ($14, $17);
+
+{new in 6.0.1}
+
+function LEClassifyKey (eventPtr: eventRecord): integer; tool ($14, $25);
+
+implementation
+end.

--- a/Tool.Interface/ListMgr.pas
+++ b/Tool.Interface/ListMgr.pas
@@ -1,0 +1,127 @@
+{$keep 'ListMgr'}
+unit ListMgr;
+interface
+
+{********************************************************
+*
+*   List Manager Interface File
+*
+*   Other USES Files Needed:  Common
+*
+*   Other Tool Sets Needed:   Tool Locator, Memory Manager,
+*                             Miscellaneous Tool Set, QuickDraw II,
+*                             Event Manager, Window Manager, Control Manager
+*
+*  Copyright 1987-1992
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common;
+
+const
+   (* Bit mask for listType *)
+   cStringFlag     =   $0001;      (* null-terminated string type *)
+   selectOnlyOne   =   $0002;      (* only 1 selection allowed    *)
+
+   (* memFlag *)
+   memDisabled     =   $40;        (* sets member flag to disabled *)
+   memSelected     =   $80;        (* sets member flag to selected *)
+
+type
+   (* Member record is defined in the Common.intf inteface file. *)
+
+   memberList = array [1..100] of memRec;   (* user may modify size *)
+
+   listRec = record
+       listRect:        rect;
+       listSize:        integer;
+       listView:        integer;
+       listType:        integer;
+       listStart:       integer;
+       listCtl:         ctlRecHndl;
+       listDraw:        procPtr;
+       listMemHeight:   integer;
+       listMemSize:     integer;
+       listPointer:     memRecPtr;
+       listRefCon:      longint;
+       listScrollClr:   barColorsPtr;
+       end;
+   listRecPtr = ^listRec;
+
+   (* List control record:  included as part of Control Record. *)
+   (* See the Common interface file for this record.            *)
+
+   (* List color table *)
+   lColorTable = record
+       listFrameClr:   integer;
+       listNorTextClr: integer;
+       listSelTextClr: integer;
+       listNorBackClr: integer;
+       listSelBackClr: integer;
+       end;
+
+
+procedure ListBootInit; tool ($1C, $01);   (* WARNING: an application should
+                                                       NEVER make this call *)
+
+procedure ListStartUp; tool ($1C, $02);
+
+procedure ListShutDown; tool ($1C, $03);
+
+function ListVersion: integer; tool ($1C, $04);
+
+procedure ListReset; tool ($1C, $05);      (* WARNING: an application should
+                                                       NEVER make this call *)
+
+function ListStatus: boolean; tool ($1C, $06);
+
+function CompareStrings (flags: integer; string1, string2: pString): integer;
+tool ($1C, $18);
+
+function CreateList (theWindow: grafPortPtr; var theList: listRec): ctlRecHndl;
+tool ($1C, $09);
+
+procedure DrawMember (theMember: memRecPtr; var theList: listRec);
+tool ($1C, $0C);
+
+procedure DrawMember2 (itemnum: integer; theListCtl: ctlRecHndl);
+tool ($1C, $11);
+               
+function GetListDefProc: procPtr; tool ($1C, $0E);
+
+procedure ListKey (flags: integer; event: eventRecord; listCtl: ctlRecHndl);
+tool ($1C, $17);
+
+procedure NewList (theMember: memRecPtr; var theList: listRec);
+tool ($1C, $10);
+
+procedure NewList2 (drawRtn: procPtr; listStart: integer; listRef: longint;
+                    listRefDesc, listSize: integer; theListCtl: ctlRecHndl);
+tool ($1C, $16);
+         
+function NextMember (firstMember: memRecPtr; var theList: listRec):
+                     memRecPtr; tool ($1C, $0B);
+ 
+function NextMember2 (itemNum: integer; theListCtl: ctlRecHndl): integer;
+tool ($1C, $12);
+
+function ResetMember (var theList: listRec): memRecPtr; tool ($1C, $0F);
+
+function ResetMember2 (theListCtl: ctlRecHndl): integer; tool ($1C, $13);
+
+procedure SelectMember (theMember: memRecPtr; var theList: listRec);
+tool ($1C, $0D);
+
+procedure SelectMember2 (itemNum: integer; theListCtl: ctlRecHndl);
+tool ($1C, $14);
+
+procedure SortList (compareRtn: procPtr; var theList: listRec); tool ($1C, $0A);
+
+procedure SortList2 (compareRtn: procPtr; theListCtl: ctlRecHndl);
+tool ($1C, $15);
+
+implementation
+end.

--- a/Tool.Interface/MIDI.pas
+++ b/Tool.Interface/MIDI.pas
@@ -1,0 +1,53 @@
+{$keep 'MIDI'}
+unit MIDI;
+interface
+
+{********************************************************
+*
+*  MIDI Tool Set Interface File
+*
+*  Other USES Files Needed: Common
+*
+*  Other Tool Sets Needed:  Tool Locator, Memory Manager;
+*                           Sound Manager, Note Synthesizer,
+*                           Note Sequencer (if using Synthesizer
+*                           or Sequencer)
+*
+*  Copyright 1987-1990
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common;
+
+procedure MidiBootInit; tool ($20, $01);   (* WARNING: an application should
+                                                       NEVER make this call *)
+
+procedure MidiStartup (theUserID, directPageAddr: integer); tool ($20, $02);
+
+procedure MidiShutdown; tool ($20, $03);
+
+function MidiVersion: integer; tool ($20, $04);
+
+procedure MidiReset; tool ($20, $05);      (* WARNING: an application should
+                                                       NEVER make this call *)
+
+function MidiStatus: boolean; tool ($20, $06);
+
+procedure MidiClock (funcNum: integer; arg: longint); tool ($20, $0B);
+
+procedure MidiControl (funcNum: integer; arg: longint); tool ($20, $09);
+
+procedure MidiDevice (funcNum: integer; driverInfo: ptr); tool ($20, $0A);
+
+function MidiInfo (funcNum: integer): longint; tool ($20, $0C);
+
+function MidiReadPacket (bufPtr: ptr; bufSize: integer): integer;
+tool ($20, $0D);
+
+function MidiWritePacket (bufPtr: ptr): integer; tool ($20, $0E);
+
+implementation
+end.

--- a/Tool.Interface/MIDISynth.pas
+++ b/Tool.Interface/MIDISynth.pas
@@ -1,0 +1,238 @@
+{$keep 'MIDISynth'}
+unit MIDISynth;
+interface
+
+{********************************************************
+*
+*  MIDISynth Tool Set Interface File
+*
+*  Other USES Files Needed:  Common
+*
+*  Copyright 1993
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common;
+
+const
+					{Error Codes}
+   msAlreadyStarted = $2301;		{MidiSynth already started.}
+   msNotStarted = $2302;		{MidiSynth never started.}
+   msNoDPMem = $2303;			{Can't get direct page memory.}
+   msNoMemBlock = $2304;		{Can't get memory block.}
+   msNoMiscTool = $2305;		{Misc Tools not started.}
+   msNoSoundTool = $2306;		{Sound Tools not started.}
+   msGenInUse = $2307;			{Ensoniq generator in use.}
+   msBadPortNum = $2308;		{Illegal port number.}
+   msPortBusy = $2309;			{Port is busy.}
+   msParamRangeErr = $230a;		{Parameter range error.}
+   msMsgQueueFull = $230b;		{Message queue full.}
+   msRecBufFull = $230c;		{Rec buffer is full.}
+   msOutputDisabled = $230d;		{MIDI output disabled.}
+   msMessageError = $230e;		{Message error.}
+   msOutputBufFull = $230f;		{MIDI output buffer is full.}
+   msDriverNotStarted = $2310;		{Driver not started.}
+   msDriverAlreadySet = $2311;		{Driver already set.}
+   msDevNotAvail = $2380;		{the requested device is not available}
+   msDevSlotBusy = $2381;		{requested slot is already in use}
+   msDevBusy = $2382;			{the requested device is already in use}
+   msDevOverrun = $2383;		{device overrun by incoming MIDI data}
+   msDevNoConnect = $2384;		{no connection to MIDI}
+   msDevReadErr = $2385;		{framing error in received MIDI data}
+   msDevVersion = $2386;		{ROM version is incompatible with device driver}
+   msDevIntHndlr = $2387;		{conflicting interrupt handler is installed}
+
+type
+   msDirectPageHndl = ^msDirectPagePtr;
+   msDirectPagePtr = ^msDirectPage;
+   msDirectPage = record
+      reserved1: array [0..11] of byte;
+      mpacketStat: integer;
+      mpacketData1: integer;
+      mpacketData2: integer;
+      seqClockFrac: byte;
+      seqClockInt: longint;
+      reserved2: array [$17..$30] of byte;
+      seqItemStat: byte;
+      seqItemData1: byte;
+      seqItemData2: byte;
+      reserved3: array [$34..$3E] of byte;
+      metroVol: byte;
+      reserved4: array [$40..$E3] of byte;
+      metroFreq: byte;
+      reserved5: array [$E6..$E9] of byte;
+      seqItemTrack: byte;
+      reserved6: byte;
+      packetBytes: byte;
+      reserved7: array [$ED..$100] of byte;
+      end;
+
+   getMSDataOutputRecHndl = ^getMSDataOutputRecPtr;
+   getMSDataOutputRecPtr = ^getMSDataOutputRec;
+   getMSDataOutputRec = record
+      directPage: msDirectPagePtr;
+      reserved: longint;
+      end;
+
+   measureRecHndl = ^measureRecPtr;
+   measureRecPtr = ^measureRec;
+   measureRec = record
+      measureNumber: integer;
+      beatNumber: integer;
+      msRemainder: integer;
+      end;
+
+   callBackRecHndl = ^callBackRecPtr;
+   callBackRecPtr = ^callBackRec;
+   callBackRec = record
+      endSeq: procPtr;
+      userMeter: procPtr;
+      mstart: procPtr;
+      mstop: procPtr;
+      packetIn: procPtr;
+      seqEvent: procPtr;
+      sysEx: procPtr;
+      packetOut: procPtr;
+      pgmChange: procPtr;
+      mContinue: procPtr;
+      sMarker: procPtr;
+      recBufFull: procPtr;
+      reserved1: procPtr;
+      reserved2: procPtr;
+      end;
+
+   seqPlayRecHndl = ^seqPlayRecPtr;
+   seqPlayRecPtr = ^seqPlayRec;
+   seqPlayRec = record
+      pBufStart: ptr;
+      reserved: longint;
+      rBufStart: ptr;
+      rBufEnd: ptr;
+      seqFlags: integer;
+      theClock: longint;
+      end;
+
+   envelopeRecHndl = ^envelopeRecPtr;
+   envelopeRecPtr = ^envelopeRec;
+   envelopeRec = record
+      attackLevel: byte;
+      attackRate: byte;
+      decay1Level: byte;
+      decay1Rate: byte;
+      decay2Level: byte;
+      decay2Rate: byte;
+      sustainLevel: byte;
+      decay3Rate: byte;
+      release1Level: byte;
+      release1Rate: byte;
+      release2Level: byte;
+      release2Rate: byte;
+      release3Rate: byte;
+      decayGain: byte;
+      velocityGain: byte;
+      pitchBendRange: byte;
+      end;
+
+   wavelistRecHndl = ^wavelistRecPtr;
+   wavelistRecPtr = ^wavelistRec;
+   wavelistRec = record
+      topKey: byte;
+      oscConfig: byte;
+      stereo: byte;
+      detune: byte;
+      waveAddrA: byte;
+      waveSizeA: byte;
+      volumeA: byte;
+      octaveA: byte;
+      semitoneA: byte;
+      findTuneA: byte;
+      wavAddrB: byte;
+      waveSizeB: byte;
+      volumeB: byte;
+      octaveB: byte;
+      semitoneB: byte;
+      fineTuneB: byte;
+      end;
+
+   instrumentRecHndl = ^instrumentRecPtr;
+   instrumentRecPtr = ^instrumentRec;
+   instrumentRec = record
+      gen1EnvRec: envelopeRec;
+      gen1WaveRecs: array[1..8] of wavelistRec;
+      gen2EnvRec: envelopeRec;
+      gen2WaveRecs: array [1..8] of wavelistRec;
+      end;
+
+   seqItemRecHndl = ^seqItemRecPtr;
+   seqItemRecPtr = ^seqItemRec;
+   seqItemRec = record
+      trackNum: byte;
+      timeStampHigh: byte;
+      timeStampLow: byte;
+      timeStampMid: byte;
+      dataByteCount: byte;
+      MIDIStat: byte;
+      dataByte1: byte;
+      dataByte2: byte;
+      end;
+
+procedure MSBootInit; tool ($23, $01);
+procedure MSStartUp; tool ($23, $02);
+procedure MSShutDown; tool ($23, $03);
+function MSVersion: integer; tool ($23, $04);
+procedure MSReset; tool ($23, $05);
+function MSStatus: Boolean; tool ($23, $06);
+
+{ This call cannot be made from ORCA/Pascal
+function ConvertToMeasure (ticksPerBeat, beats: integer; seqClockTics: longint):
+   MeasureRec; tool ($23, $21);
+}
+
+function ConvertToTime (ticksPerBeat, beats, beatNum, measure: integer): longint;
+   tool ($23, $20);
+procedure DeleteTrack (trackNum: integer; sequence: ptr); tool ($23, $1D);
+
+{ This call cannot be made from ORCA/Pascal
+function GetMSData: getMSDataOutputRec; tool ($23, $1F);
+}
+
+procedure GetTuningTable (table: ptr); tool ($23, $25);
+procedure InitMIDIDriver (slot, internal, userID: integer; driver: procPtr);
+   tool ($23, $27);
+procedure KillAllNotes; tool ($23, $0D);
+function Locate (timeStamp: longint; seqBuffer: ptr): seqItemRecPtr;
+   tool ($23, $11);
+function LocateEnd (seqBuffer: ptr): ptr; tool ($23, $1B);
+procedure Merge (buffer1, buffer2: ptr); tool ($23, $1C);
+procedure MIDIMessage (destination, numBytes, message, dataByte1,
+   dataByte2: integer); tool ($23, $1A);
+procedure MSResume; tool ($23, $23);
+procedure MSSuspend; tool ($23, $22);
+procedure PlayNote (channel, noteNum, volume: integer); tool ($23, $0B);
+procedure RemoveMIDIDriver; tool ($23, $28);
+procedure SeqPlayer (var sequence: seqPlayRec); tool ($23, $15);
+procedure SetBasicChannel (channel: integer); tool ($23, $09);
+procedure SetBeat (duration: integer); tool ($23, $19);
+procedure SetCallBack (var buffer: callBackRec); tool ($23, $17);
+procedure SetInstrument (inst: instrumentRecPtr; number: integer);
+   tool ($23, $14);
+procedure SetMetro (volume, frequency: integer; wave: ptr); tool ($23, $1E);
+procedure SetMIDIMode (mode: integer); tool ($23, $0A);
+procedure SetMIDIPort (inputDisable, outputDisable: integer); tool ($23, $13);
+procedure SetPlayTrack (trackNum, playState: integer); tool ($23, $0F);
+procedure SetRecTrack (trackNum: integer); tool ($23, $0E);
+procedure SetTempo (tempo: integer); tool ($23, $16);
+procedure SetTrackOut (trackNum, path: integer); tool ($23, $26);
+procedure SetTuningTable (table: ptr); tool ($23, $24);
+procedure SetVelComp (velocity: integer); tool ($23, $24);
+procedure StopNote (channel, noteNum: integer); tool ($23, $0C);
+procedure SysExOut (message: ptr; delay: integer; monitor: procPtr);
+   tool ($23, $18);
+procedure TrackToChannel (trackNum, channel: integer); tool ($23, $10);
+
+implementation
+
+end.

--- a/Tool.Interface/MemoryMgr.pas
+++ b/Tool.Interface/MemoryMgr.pas
@@ -1,0 +1,125 @@
+{$keep 'MemoryMgr'}
+unit MemoryMgr;
+interface
+
+{********************************************************
+*
+*  Memory Manager Interface File
+*
+*  Other USES Files Needed: Common
+*
+*  Other Tool Sets Needed:  Tool Locator
+*
+*  Copyright 1987-1992
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common;
+
+const
+   attrNoPurge     =   $0000;      (* not purgeable                      *)
+   attrBank        =   $0001;      (* fixed bank                         *)
+   attrAddr        =   $0002;      (* fixed address                      *)
+   attrPage        =   $0004;      (* page aligned                       *)
+   attrNoSpec      =   $0008;      (* may not use special memory         *)
+   attrNoCross     =   $0010;      (* may not cross bank boundary        *)
+   attrPurge1      =   $0100;      (* purge level 1                      *)
+   attrPurge2      =   $0200;      (* purge level 2                      *)
+   attrPurge3      =   $0300;      (* purge level 3                      *)
+   attrPurge       =   $0300;      (* test or set both purge bits        *)
+   attrHandle      =   $1000;      (* block of handles - reserved for MM *)
+   attrSystem      =   $2000;      (* system handle - reserved for MM    *)
+   attrFixed       =   $4000;      (* fixed block                        *)
+   attrLocked      =   $8000;      (* locked block                       *)
+
+type
+   OOMHeader = record
+       reserved:   longint;
+       version:    integer;        (* must be zero *)
+       signature:  integer;        (* set to $A55A *)
+       end;
+
+
+procedure MMBootInit; tool ($02, $01);     (* WARNING: an application should
+                                                       NEVER make this call *)
+
+function MMStartUp: integer; tool ($02, $02);
+
+procedure MMShutDown (userID: integer); tool ($02, $03);
+
+function MMVersion: integer; tool ($02, $04);
+
+procedure MMReset; tool ($02, $05);        (* WARNING: an application should
+                                                       NEVER make this call *)
+
+function MMStatus: boolean; tool ($02, $06);
+
+procedure AddToOOMQueue (var headerPtr: OOMHeader); tool ($02, $0C);
+
+procedure BlockMove (sourcPtr, destPtr: ptr; count: longint); tool ($02, $2B);
+
+procedure CheckHandle (theHandle: handle); tool ($02, $1E);
+
+procedure CompactMem; tool ($02, $1F);
+
+procedure DisposeAll (userID: integer); tool ($02, $11);
+
+procedure DisposeHandle (theHandle: handle); tool ($02, $10);
+
+function FindHandle (memLocation: ptr): handle; tool ($02, $1A);
+
+function FreeMem: longint; tool ($02, $1B);
+
+function GetHandleSize (theHandle: handle): longint; tool ($02, $18);
+
+procedure HandToHand (sourceHandle, destHandle: handle; count: longint);
+tool ($02, $2A);
+
+procedure HandToPtr (sourceHandle: handle; destPtr: ptr; count: longint);
+tool ($02, $29);
+
+procedure HLock (theHandle: handle); tool ($02, $20);
+
+procedure HLockAll (userID: integer); tool ($02, $21);
+
+procedure HUnLock (theHandle: handle); tool ($02, $22);
+
+procedure HUnLockAll (userID: integer); tool ($02, $23);
+
+function MaxBlock: longint; tool ($02, $1C);
+
+function NewHandle (blockSize: longint; userID, memAttributes: integer;
+                    memLocation: univ ptr): handle; tool ($02, $09);
+
+procedure PtrToHand (srcPtr: ptr; theHandle: handle; count: longint);
+tool ($02, $28);
+
+procedure PurgeAll (userID: integer); tool ($02, $13);
+
+procedure PurgeHandle (theHandle: handle); tool ($02, $12);
+
+function RealFreeMem: longint; tool ($02, $2F);
+
+procedure ReAllocHandle (blockSize: longint; userID, memAttributes: integer;
+                         memLocation: ptr; theHandle: handle); tool ($02, $0A);
+
+procedure RemoveFromOOMQueue (var headerPtr: OOMHeader); tool ($02, $0D);
+
+procedure RestoreHandle (theHandle: handle); tool ($02, $0B);
+
+function SetHandleID (newID: integer; theHandle: handle): integer;
+tool ($02, $30);
+
+procedure SetHandleSize (newSize: longint; theHandle: handle); tool ($02, $19);
+
+procedure SetPurge (purgeLevel: integer; theHandle: handle); tool ($02, $24);
+
+procedure SetPurgeAll (purgeLevel, userID: integer); tool ($02, $25);
+
+function TotalMem: longint; tool ($02, $1D);
+
+implementation
+end.

--- a/Tool.Interface/MenuMgr.pas
+++ b/Tool.Interface/MenuMgr.pas
@@ -1,0 +1,270 @@
+{$keep 'MenuMgr'}
+unit MenuMgr;
+interface
+
+{********************************************************
+*
+*   Menu Manager Interface File
+*
+*   Other USES Files Needed:  Common
+*
+*   Other Tool Sets Needed:   Tool Locator, Memory Manager,
+*                             QuickDraw II, Event Manager,
+*                             Window Manager, Control Manager
+*
+*  Copyright 1987-1992
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common;
+
+const
+   (* Masks for MenuFlag *)
+   mInvis          =   $0004;      (* set if menu is not visible       *)
+   mCustom         =   $0010;      (* set if menu is a custom menu     *)
+   mXor            =   $0020;      (* set if menu is hilited using XOR *)
+   mSelected       =   $0040;      (* set if menu is highlighted       *)
+   mDisabled       =   $0080;      (* set if menu is disabled          *)
+
+   (* Messages to menu definition procedures *)
+   mDrawMsg        =   $0000;      (* draw menu             *)
+   mChooseMsg      =   $0001;      (* hit test item         *)
+   mSizeMsg        =   $0002;      (* compute menu size     *)
+   mDrawTitle      =   $0003;      (* draw menu's title     *)
+   mDrawMItem      =   $0004;      (* draw item             *)
+   mGetMItemID     =   $0005;      (* return item ID number *)
+
+   (* Inputs to SetMenuFlag routine *)
+   customMenu      =   $0010;      (* menu is a custom menu                  *)
+   disableMenu     =   $0080;      (* menu will be dimmed and not selectable *)
+   enableMenu      =   $FF7F;      (* menu will not be dimmed; is selectable *)
+   colorReplace    =   $FFDF;      (* menu title and background will be      *)
+                                   (*   redrawn and hilighted                *)
+   standardMenu    =   $FFEF;      (* menu considered a standard menu        *)
+
+   (* Inputs to SetMItemFlag routine *)
+   xorMItemHilite  =   $0020;      (* menu title area XORed to highlight    *)
+   underMItem      =   $0040;      (* underline item                        *)
+   noUnderMItem    =   $FFBF;      (* don't underline item                  *)
+   colorMItemHilite =  $FFDF;      (* menu title and background highlighted *)
+   enableItem      =   $FF7F;      (* enable menu item                      *)
+   disableItem     =   $0080;      (* disable menu item                     *)
+
+   (* Reference values for new 5.0 Menu Manager calls *)
+   refIsPointer    =   0;
+   refIsHandle     =   1;
+   refIsResource   =   2;
+
+type
+   menuItemTemplate = record
+       version:       integer;     (* must be zero *)
+       itemID:        integer;
+       itemChar:      byte;
+       itemAltChar:   byte;
+       itemCheck:     integer;
+       itemFlag:      integer;
+       itemTitleRef:  longint;
+       end;
+         
+   menuTemplate = record
+       version:       integer;     (* must be zero *)
+       menuID:        integer;
+       menuFlag:      integer;
+       menuTitleRef:  longint;
+   (* Array of pointers/handles/resource IDs of menu items.  Set array size  *)
+   (* for application.                                                       *)
+       itemRefs:      array [1..10] of longint;
+       terminator:    longint;     (* must be zero *)
+       end;
+         
+   menuBarTemplate = record
+       version:       integer;     (* must be zero *)
+       menuBarFlag:   integer;
+   (* Array of pointers/handles/resource IDs for menus.  Set array size for  *)
+   (* application.                                                           *)
+       menuRefs:      array [1..10] of longint;
+       terminator:    longint;     (* must be zero *)
+       end;
+
+   menuResult = record
+      menuID: integer;
+      firstHandle, secondHandle: handle;
+      end;
+
+   (* The MenuBar record and MenuRecord are defined in the Common.intf  *)
+   (* interface file.                                                   *)
+
+
+procedure MenuBootInit; tool ($0F, $01);   (* WARNING: an application should
+                                                       NEVER make this call *)
+
+procedure MenuStartUp (userID, dPageAddr: integer); tool ($0F, $02);
+
+procedure MenuShutDown; tool ($0F, $03);
+
+function MenuVersion: integer; tool ($0F, $04);
+
+procedure MenuReset; tool ($0F, $05);      (* WARNING: an application should
+                                                       NEVER make this call *)
+
+function MenuStatus: boolean; tool ($0F, $06);
+
+procedure CalcMenuSize (newWidth, newHeight, menuNum: integer); tool ($0F, $1C);
+
+procedure CheckMItem (checkedFlag: boolean; itemNum: integer); tool ($0F, $32);
+
+function CountMItems (menuNum: integer): integer; tool ($0F, $14);
+
+procedure DeleteMenu (menuNum: integer); tool ($0F, $0E);
+
+procedure DeleteMItem (itemNum: integer); tool ($0F, $10);
+
+procedure DisableMItem (itemNum: integer); tool ($0F, $31);
+
+procedure DisposeMenu (theMenuHandle: menuHandle); tool ($0F, $2E);
+
+procedure DrawMenuBar; tool ($0F, $2A);
+
+procedure EnableMItem (itemNum: integer); tool ($0F, $30);
+
+function FixMenuBar: integer; tool ($0F, $13);
+
+procedure FlashMenuBar; tool ($0F, $0C);
+
+function GetBarColors: longint; tool ($0F, $18);
+
+function GetMenuBar: ctlRecHndl; tool ($0F, $0A);
+
+function GetMenuFlag (menuNum: integer): integer; tool ($0F, $20);
+
+function GetMenuMgrPort: grafPortPtr; tool ($0F, $1B);
+
+function GetMenuTitle (menuNum: integer): cStringPtr; tool ($0F, $22);
+
+function GetMHandle (menuNum: integer): menuHandle; tool ($0F, $16);
+
+function GetMItem (itemNum: integer): cStringPtr; tool ($0F, $25);
+
+function GetMItemBlink: integer; tool ($0F, $4F);
+
+function GetMItemFlag (itemNum: integer): integer; tool ($0F, $27);
+
+function GetMItemFlag2 (itemNum: integer): integer; tool ($0F, $4C);
+
+function GetMItemIcon (itemNum: integer): longint; tool ($0F, $48);
+
+function GetMItemMark (itemNum: integer): integer; tool ($0F, $34);
+
+function GetMItemStruct (itemNum: integer): longint; tool ($0F, $4A);
+
+function GetMItemStyle (itemNum: integer): integer; tool ($0F, $36);
+
+function GetMTitleStart: integer; tool ($0F, $1A);
+
+function GetMTitleWidth (menuNum: integer): integer; tool ($0F, $1E);
+
+function GetPopUpDefProc: procPtr; tool ($0F, $3B);
+
+function GetSysBar: ctlRecHndl; tool ($0F, $11);
+
+procedure HideMenuBar; tool ($0F, $45);
+
+procedure HiliteMenu (hiliteFlag: boolean; menuNum: integer); tool ($0F, $2C);
+
+procedure InitPalette; tool ($0F, $2F);
+
+procedure InsertMenu (addMenu: menuHandle; insertAfter: integer);
+tool ($0F, $0D);
+
+procedure InsertMItem (addItem: cStringPtr; insertAfter, menuNum: integer);
+tool ($0F, $0F);
+
+procedure InsertMItem2 (refDescriptor: integer; menuItemTRef: longint;
+                        insertAfter, menuNum : integer); tool ($0F, $3F);
+
+procedure InsertPathMItems (flags: integer; pathPtr: gsosInString;
+   deviceNum, menuID, afterID, startingID: integer; result: menuResult);
+   tool ($0F, $50);
+
+function MenuGlobal (menuGlobalMask: integer): integer; tool ($0F, $23);
+
+procedure MenuKey (var theTask: eventRecord; theMenuBar: ctlRecHndl); tool ($0F, $09);
+
+procedure MenuNewRes; tool ($0F, $29);
+
+procedure MenuRefresh (redrawPtr: procPtr); tool ($0F, $0B);
+
+procedure MenuSelect (var theTask: eventRecord; theMenuBar: ctlRecHndl);
+tool ($0F, $2B);
+
+function NewMenu (newMenuString: textPtr): menuHandle; tool ($0F, $2D);
+
+function NewMenu2 (refDescriptor: integer; menuTRef: longint):
+                   menuHandle; tool ($0F, $3E);
+                  
+function NewMenuBar (theWindow: grafPortPtr): ctlRecHndl; tool ($0F, $15);
+
+function NewMenuBar2 (refDescriptor: integer; menuBarTRef: univ longint;
+                      theWindow: grafPortPtr): menuBarHandle; tool ($0F, $43);
+                     
+function PopUpMenuSelect (selection, currentLeft, currentTop, flag: integer;
+                          theMenu: menuHandle): integer; tool ($0F, $3C);
+                  
+procedure RemoveMItemStruct (itemID: integer); tool ($0F, $4B);
+
+procedure SetBarColors (newBarColor, newInvertColor, newOutColor: integer);
+tool ($0F, $17);
+
+procedure SetMenuBar (theBarHandle: ctlRecHndl); tool ($0F, $39);
+
+procedure SetMenuFlag (newvalue, menuNum: integer); tool ($0F, $1F);
+
+procedure SetMenuID (newMenuNum, curMenuNum: integer); tool ($0F, $37);
+
+procedure SetMenuTitle (newTitle: cStringPtr; menuNum: integer);
+tool ($0F, $21);
+
+procedure SetMenuTitle2 (refDescriptor: integer; titleRef: longint;
+                         menuNum: integer); tool ($0F, $40);
+               
+procedure SetMItem (newItem: cStringPtr; itemNum: integer); tool ($0F, $24);
+
+procedure SetMItem2 (refDescriptor: integer; menuItemTRef: longint;
+                     menuItem: integer); tool ($0F, $41);
+
+procedure SetMItemBlink (count: integer); tool ($0F, $28);
+
+procedure SetMItemFlag (newValue, itemNum: integer); tool ($0F, $26);
+
+procedure SetMItemFlag2 (newValue, itemNum: integer); tool ($0F, $4D);
+
+procedure SetMItemIcon (iconDesc: integer; iconRef: univ longint;
+   itemID: integer); tool ($0F, $47);
+
+procedure SetMItemID (newItemNum, curItemNum: integer); tool ($0F, $38);
+
+procedure SetMItemMark (mark, itemNum: integer); tool ($0F, $33);
+
+procedure SetMItemName (newName: pStringPtr; itemNum: integer); tool ($0F, $3A);
+
+procedure SetMItemName2 (refDescriptor: integer; titleRef: longint;
+                         menuItem: integer); tool ($0F, $42);
+            
+procedure SetMItemStruct (itemStructDesc: integer; itemStructRef: univ longint;
+   itemNum: integer); tool ($0F, $49);
+
+procedure SetMItemStyle (textStyle, itemNum: integer); tool ($0F, $35);
+
+procedure SetMTitleStart (xStart: integer); tool ($0F, $19);
+
+procedure SetMTitleWidth (newWidth, menuNum: integer); tool ($0F, $1D);
+
+procedure SetSysBar (theBarHandle: ctlRecHndl); tool ($0F, $12);
+
+procedure ShowMenuBar; tool ($0F, $46);
+
+implementation
+end.

--- a/Tool.Interface/MscToolSet.pas
+++ b/Tool.Interface/MscToolSet.pas
@@ -1,0 +1,185 @@
+{$keep 'MscToolSet'}
+unit MscToolSet;
+interface
+
+{********************************************************
+*
+*   Miscellaneous Tool Set Interface File
+*
+*   Other USES Files Needed: Common
+*
+*   Other Tool Sets Needed:  Tool Locator, Memory Manager
+*
+*  Copyright 1987-1992, 1993
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common;
+
+type
+   queueHeader = record
+       reserved1:  longint;
+       reserved2:  integer;
+       signature:  integer;    (* set to $A55A *)
+       end;
+   queueHeaderPtr = ^queueHeader;
+
+   intStateRecord = record
+       irq_A:       integer;
+       irq_X:       integer;
+       irq_Y:       integer;
+       irq_S:       integer;
+       irq_D:       integer;
+       irq_P:       byte;
+       irq_DB:      byte;
+       irq_e:       byte;
+       irq_K:       byte;
+       irq_PC:      integer;
+       irq_state:   byte;
+       irq_shadow:  integer;
+       irq_mslot:   byte;
+       end;
+
+
+procedure MTBootInit; tool ($03, $01);     (* WARNING: an application should
+                                                       NEVER make this call *)
+
+procedure MTStartUp; tool ($03, $02);
+
+procedure MTShutDown; tool ($03, $03);
+
+function MTVersion: integer; tool ($03, $04);
+
+procedure MTReset; tool ($03, $05);        (* WARNING: an application should
+                                                       NEVER make this call *)
+
+function MTStatus: boolean; tool ($03, $06);
+
+procedure AddToQueue (newEntry, headerPtr: queueHeaderPtr); tool ($03, $2E);
+
+function ConvSeconds (convVerb: integer; seconds: longint; datePtr: ptr)
+                      : longint; tool ($03, $37);
+
+procedure DeleteFromQueue (newEntry, headerPtr: queueHeaderPtr); tool ($03, $2F);
+
+procedure SetInterruptState (var interruptState: intStateRecord;
+                             bytesDesired: integer); tool ($03, $30);
+
+procedure GetInterruptState (var interruptState: intStateRecord;
+                             bytesDesired: integer); tool ($03, $31);
+
+function GetIntStateRecSize: integer; tool ($03, $32);
+
+function GetCodeResConverter: procPtr; tool ($03, $34);
+
+procedure WriteBRam (bufferAddress: ptr); tool ($03, $09);
+
+procedure ReadBRam (bufferAddress: ptr); tool ($03, $0A);
+
+procedure WriteBParam (theData, paramRefNum: integer); tool ($03, $0B);
+
+function ReadBParam (paramRefNum: integer): integer; tool ($03, $0C);
+
+(* ReadTimeHex returns 8 bytes - no direct interface is possible *)
+
+(* To set up parameters for WriteTimeHex, you could shift the first value *)
+(* and then OR it with the second value:  month_day := month << 8 | day   *)
+
+procedure WriteTimeHex (month_day, year_hour, minute_second: integer);
+tool ($03, $0E);
+
+procedure ReadASCIITime (bufferAddress: ptr); tool ($03, $0F);
+
+(* FWEntry returns 4 integers - no direct interface is possible *)
+
+function GetAddr (refNum: integer): ptr; tool ($03, $16);
+
+function GetTick: longint; tool ($03, $25);
+
+function GetIRQEnable: integer; tool ($03, $29);
+
+procedure IntSource (srcRefNum: integer); tool ($03, $23);
+
+procedure ClampMouse (xMinClamp, xMaxClamp, yMinClamp, yMaxClamp: integer);
+tool ($03, $1C);
+
+procedure ClearMouse; tool ($03, $1B);
+
+(* GetMouseClamp returns 4 integers - no direct interface is possible *)
+
+procedure HomeMouse; tool ($03, $1A);
+
+procedure InitMouse (mouseSlot: integer); tool ($03, $18);
+
+procedure PosMouse (xPos, yPos: integer); tool ($03, $1E);
+
+(* ReadMouse returns 2 integers and 2 bytes - no direct interface is possible *)
+(* ReadMouse2 returns 3 integers - no direct interface is possible            *)
+
+function ServeMouse: integer; tool ($03, $1F);
+
+procedure SetMouse (mouseMode: integer); tool ($03, $19);
+
+procedure SetAbsClamp (xMinClamp, xMaxClamp, yMinClamp, yMaxClamp: integer);
+tool ($03, $2A);
+
+(* GetAbsClamp returns 4 integers - no direct interface is possible *)
+
+function PackBytes (startHandle: handle; var size: integer; bufferPtr: ptr;
+                    bufferSize: integer): integer; tool ($03, $26);
+
+function UnPackBytes (packBufferPtr: ptr; bufferSize: integer;
+                      startHandle: handle; var size: integer): integer;
+tool ($03, $27);
+
+function Munger (destPtr: handle; var destLen: integer; targPtr: ptr;
+                 targLen: integer; replPtr: ptr; replLen: integer;
+                 padPtr: ptr): integer; tool ($03, $28);
+
+procedure SetHeartBeat (taskPtr: ptr); tool ($03, $12);
+
+procedure DelHeartBeat (taskPtr: ptr); tool ($03, $13);
+
+procedure ClrHeartBeat; tool ($03, $14);
+
+procedure SysBeep; tool ($03, $2C);
+
+procedure SysBeep2 (beepType: integer); tool ($03, $38);
+
+procedure SysFailMgr (errorCode: integer; failString: univ pStringPtr);
+tool ($03, $15);
+
+function GetNewID (IDTag: integer): integer; tool ($03, $20);
+
+procedure DeleteID (IDTag: integer); tool ($03, $21);
+
+procedure StatusID (IDTag: integer); tool ($03, $22);
+
+procedure SetVector (vectorRefNum: integer; vectorPtr: ptr); tool ($03, $10);
+
+function GetVector (vectorRefNum: integer): ptr; tool ($03, $11);
+
+procedure VersionString (flags: integer; theVersion: longint;
+   str: univ cStringPtr); tool ($03, $39);
+
+function WaitUntil (delayFrom, delayAmount: integer): integer; tool ($03, $3A);
+
+function ScanDevices: integer; tool ($03, $3D);
+
+procedure ShowBootInfo (str: cStringPtr; icon: ptr); tool ($03, $3C);
+
+function StringToText (flags: integer; textPtr: cStringPtr; textLen: integer;
+   result: gsosOutStringPtr): longint; tool ($03, $3B);
+
+{new in 6.0.1}
+
+function AlertMessage (msgTable: ptr; msgNum: integer; subs: ptr): integer;
+tool($03, $3E);
+
+function DoSysPrefs (bitsToClear, bitsToSet: integer): integer; tool ($03, $3F);
+
+implementation
+end.

--- a/Tool.Interface/MultiMedia.pas
+++ b/Tool.Interface/MultiMedia.pas
@@ -1,0 +1,248 @@
+{$keep 'MultiMedia'}
+unit MultiMedia;
+interface
+
+{********************************************************
+*
+*  MultiMedia Sequence Editor, Scheduler
+*
+*  Other USES Files Needed:  Common
+*
+*  Other Tool Sets Needed:   Tool Locator
+*
+*  Copyright 1992, 1993
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common;
+
+const
+   inChapters = 1;
+   inFrames = 2;
+   inTimes = 3;
+
+   mcCInit = 1;                         {control values for MCControl}
+   mcCEject = 2;
+   mcCVideoOn = 3;
+   mcCVideoOff = 4;
+   mcCDisplayOn = 5;
+   mcCDisplayOff = 6;
+   mcCBlankVideo = 7;
+   mcCDefaultCom = 8;
+   mcCLockDev = 9;
+   mcCUnLockDev = 10;
+
+   mcC8Data1Stop = 40;
+   mcC7Data1Stop = 41;
+   mcC6Data1Stop = 42;
+   mcC5Data1Stop = 43;
+   mcC8Data2Stop = 44;
+   mcC7Data2Stop = 45;
+   mcC6Data2Stop = 46;
+   mcC5Data2Stop = 47;
+   
+   mcCBaudDflt = 50;
+
+   mcCBaud50 = 51;
+   mcCBaud75 = 52;
+   mcCBaud110 = 53;
+   mcCBaud134 = 54;
+   mcCBaud150 = 55;
+   mcCBaud300 = 56;
+   mcCBaud600 = 57;
+   mcCBaud1200 = 58;
+   mcCBaud1800 = 59;
+   mcCBaud2400 = 60;
+   mcCBaud3600 = 61;
+   mcCBaud4800 = 62;
+   mcCBaud7200 = 63;
+   mcCBaud9600 = 64;
+   mcCBaud19200 = 65;
+
+   mcCModem = 100;
+   mcCPrinter = 101;
+
+   mcCIgnoreDS = 200;
+   mcCReportDS = 201;
+
+   mcFTypes = 0;                        {status values for MCGetFeatures}
+   mcFStep = 1;
+   mcFRecord = 2;
+   mcFVideo = 3;
+   mcFEject = 4;
+   mcFLock = 5;
+   mcFVDisplay = 6;
+   mcFVOverlay = 7;
+   mcFVOChars = 8;
+   mcFVolume = 9;
+
+   mcSUnknown = 0;                      {status values for MCGetStatus}
+   mcSDeviceType = $0000;
+   mcSLaserDisc = 1;
+   mcSCDAudio = 2;
+   mcSCDLaserCD = 3;
+   mcSVCR = 4;
+   mcSCamCorder = 5;
+   mcSPlayStatus = $0001;
+   mcSPlaying = 1;
+   mcSStill = 2;
+   mcSParked = 3;
+   mcSDoorStatus = $0002;
+   mcSDoorOpen = 1;
+   mcSDoorClosed = 2;
+   mcSDiscType = $0003;
+   mcS_CLV = 1;
+   mcS_CAV = 2;
+   mcS_CDV = 3;
+   mcS_CD = 4;
+   mcSDiscSize = $0004;
+   mcSDisc3inch = 3;
+   mcSDisk5inch = 5;
+   mcSDisk8inch = 8;
+   mcSDisk12inch = 12;
+   mcSDiskSide = $0005;
+   mcSSideOne = 1;
+   mcSSideTwo = 2;
+   mcSVolumeL = $0006;
+   mcSVolumeR = $0007;
+
+   mcElapsedTrack = 0;                  {MCGetTimes selector values}
+   mcRemainTrack = 1;
+   mcElapsedDisc = 2;
+   mcRemainDisc = 3;
+   mcTotalDisc = 4;
+
+   mcTotalFrames = 5;
+   mcTracks = 6;
+   mcDiscID = 7;
+   
+   AudioOff = 0;                        {Audio values}
+   AudioRight = 1;
+   AudioLinR = 2;
+   AudioMinR = 3;
+   AudioRinL = 4;
+   AudioRinLR = 5;
+   AudioReverse = 6;
+   AudioRinLMR = 7;
+   AudioLeft = 8;
+   AudioSterio = 9;
+   AudioLinLR = 10;
+   AudioLinLMR = 11;
+   AudioMinL = 12;
+   AudioMinLRinR = 13;
+   AudioMonLLinR = 14;
+   AudioMonaural = 15;
+           
+procedure MCBootInit; tool ($26, $01);
+
+procedure MCStartUp (userID: integer); tool ($26, $02);
+
+procedure MCShutDown; tool ($26, $03);
+
+function MCVersion: integer; tool ($26, $04);
+
+procedure MCReset; tool ($26, $05);
+
+function MCStatus: boolean; tool ($26, $06);
+
+procedure MCLoadDriver (mcChannelNo: integer); tool ($26, $0A);
+
+procedure MCUnLoadDriver (mcChannelNo: integer); tool ($26, $0B);
+
+procedure MCDStartUp (mcChannelNo: integer; portnameptr: pString;
+                       drvrUserID: integer); tool ($26, $14);
+
+procedure MCDShutDown (mcChannelNo: integer); tool ($26, $15);
+
+function MCBinToTime (mcBinVal: longint): longint; tool ($26, $0D);
+
+procedure MCControl (mcChannelNo, ctlcommand: integer); tool ($26, $1B);
+
+function MCGetDiscID (mcChannelNo: integer): longint; tool ($26, $28);
+
+procedure MCGetDicTitle (mcDiscID: longint; var PStrPtr: pString);
+   tool ($26, $12);
+
+function MCGetDiscTOC (mcChannelNo, mcTrackNo: integer): longint;
+   tool ($26, $27);
+
+procedure MCGetErrorMsg (mcErrorNo: integer; var PStrPtr: pString);
+   tool ($26, $09);
+
+function MCGetFeatures (mcChannelNo, mcFeatSel: integer): longint;
+   tool ($26, $16);
+
+procedure MCGetName (mcChannelNo: integer; var PStrPtr: pString);
+   tool ($26, $2D);
+
+function MCGetNoTracks (mcChannelNo: integer): integer; tool ($26, $29);
+
+function MCGetPosition (mcChannelNo, mcUnitType: integer): longint;
+   tool ($26, $24);
+
+procedure MCGetProgram (mcDiscID: longint; var PStrPtr: pString);
+   tool ($26, $10);
+
+procedure MCGetSpeeds (mcChannelNo: integer; var PStrPtr: pString);
+   tool ($26, $1D);
+
+function MCGetStatus (mcChannelNo, mcStatusSel: integer): integer;
+   tool ($26, $1A);
+
+function MCGetTimes (mcChannelNo, mcTimeSel: integer): longint; tool ($26, $26);
+
+procedure MCGetTrackTitle (mcDiscID: longint; mcTrackNo: integer;
+   var PStrPtr: pString); tool ($26, $0E);
+
+procedure MCJog (mcChannelNo, mcUnitType: integer; mcNJog: longint;
+   mcJogRepeat: integer); tool ($26, $20);
+
+procedure MCPause (mcChannelNo: integer); tool ($26, $18);
+
+procedure MCPlay (mcChannelNo: integer); tool ($26, $17);
+
+procedure MCRecord (mcChannelNo: integer); tool ($26, $2A);
+
+procedure MCSetAudio (mcChannelNo, mcAudioCtl: integer); tool ($26, $25);
+
+procedure MCSetVolume (mcChannelNo, mcLeftVol, mcRightVol: integer);
+   tool ($26, $2E);
+
+procedure MCScan (mcChannelNo, mcDirection: integer); tool ($26, $1C);
+
+function MCSearchDone (mcChannelNo: integer): boolean; tool ($26, $22);
+
+procedure MCSearchTo (mcChannelNo, mcUnitType: integer; searchLoc: longint);
+   tool ($26, $21);
+
+procedure MCSearchWait (mcChannelNo: integer); tool ($26, $23);
+
+procedure MCSendRawData (mcChannelNo: integer; mcNativePtr: gsosInString);
+   tool ($26, $19);
+
+procedure MCSetDiscTitle (mcDiscID: longint; titlePtr: pString);
+   tool ($26, $13);
+
+procedure MCSetProgram (mcDiscID: longint; titlePtr: gsosInString);
+   tool ($26, $11);
+
+procedure MCSetTrackTitle (mcDiscID: longint; trackNum: integer;
+   titlePtr: pString); tool ($26, $0F);
+
+procedure MCSpeed (mcChannelNo, mcFPS: integer); tool ($26, $1E);
+
+procedure MCStop (mcChannelNo: integer); tool ($26, $2B);
+
+procedure MCStopAt (mcChannelNo, mcUnitType: integer; mcStopLoc: longint);
+   tool ($26, $1F);
+
+function MCTimeToBin (mcTimeValue: longint): longint; tool ($26, $0C);
+
+procedure MCWaitRawData (mcChannelNo: integer; var result: gsosOutString;
+   tickwait, term_mask: integer); tool ($26, $2C);
+
+implementation                       
+end.

--- a/Tool.Interface/ORCAShell.pas
+++ b/Tool.Interface/ORCAShell.pas
@@ -1,0 +1,440 @@
+{$keep 'ORCAShell'}
+unit ORCAShell;
+interface
+
+{********************************************************
+*
+*  ORCA Shell Interface File
+*
+*  Notes:  Each call refers to a data control block (DCB),
+*          defined as a record.  Calls which return values
+*          store the output into the DCB.
+*          Each call returns an error number.
+*
+*  Copyright 1987-1992
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses Common;
+
+type
+   changeVectorDCB = record
+      reserved: integer;
+      vector: integer;
+      proc: procPtr;
+      oldProc: procPtr;
+      end;
+
+   changeVectorDCBGS = record
+      pcount: integer;
+      reserved: integer;
+      vector: integer;
+      proc: procPtr;
+      oldProc: procPtr;
+      end;
+
+   consoleOutDCB = record
+      ch: char;
+      end;
+
+   consoleOutDCBGS = record
+      pcount: integer;
+      ch: char; 
+      end;
+
+   directionDCB = record
+      device: integer;
+      result: integer;
+      end;
+
+   directionDCBGS = record
+      pcount: integer;
+      device: integer;
+      direct: integer;
+      end;
+
+   errorDCB = record
+      errorNumber: integer;
+      end;
+
+   errorDCBGS = record
+      pcount: integer;
+      error: integer;
+      end;
+
+   executeDCB = record
+      flag: integer;
+      commandString: textPtr;
+      end;
+
+   executeDCBGS = record
+      pcount: integer;
+      flag: integer;
+      comm: textPtr;
+      end;
+
+   expandDevicesDCB = record
+      name: pathPtr;
+      end;
+
+   expandDevicesDCBGS = record
+      pcount: integer;
+      inName: gsosInStringPtr;
+      outName: gsosOutStringPtr;
+      end;
+
+   exportDCB = record
+      name: pStringPtr;
+      flags: integer;
+      end;
+
+   exportDCBGS = record
+      pcount: integer;
+      name: gsosInStringPtr;
+      flags: integer;
+      end;
+
+   fastFileDCB = record
+      action: integer;
+      index: integer;
+      flags: integer;
+      file_handle: handle;
+      file_length: longint;
+      name: pathPtr;
+      access: integer;
+      file_type: integer;
+      auxType: longint;
+      storage_type: integer;
+      create_date: integer;
+      create_time: integer;
+      mod_date: integer;
+      mod_time: integer;
+      blocks_used: longint;
+      end;
+
+   fastFileDCBGS = record
+      pcount: integer;
+      action: integer;
+      index: integer;
+      flags: integer;
+      fileHandle: handle;
+      pathName: gsosInStringPtr;
+      access: integer;
+      fileType: integer;
+      auxType: longint;
+      storageType: integer;
+      createDate: timeField;
+      modDate: timeField;
+      option: optionListPtr;
+      fileLength: longint;
+      blocksUsed: longint;
+      end;
+
+   getCommandDCB = record
+      index: integer;
+      restart: integer;
+      reserved: integer;
+      command: integer;
+      name: packed array [0..15] of char;
+      end;
+
+   getCommandDCBGS = record
+      pcount: integer;
+      index: integer;
+      restart: integer;
+      reserved: integer;
+      command: integer;
+      name: packed array [0..15] of char;
+      end;
+
+   IODevicesDCB = record
+      output_type: integer;
+      output_addr: procPtr;
+      error_type: integer;
+      error_addr: procPtr;
+      input_type: integer;
+      input_addr: procPtr;
+      end;
+
+   IODevicesDCBGS = record
+      pcount: integer;
+      outputType: integer;
+      outputAddr: procPtr;
+      errorType: integer;
+      errorAddr: procPtr;
+      inputType: integer;
+      inputAddr: procPtr;
+      end;
+
+   initWildcardDCB = record
+      wFile: pathPtr;
+      flags: integer;
+      end;
+
+   initWildcardDCBGS = record
+      pcount: integer;
+      wFile: gsosInStringPtr;
+      flags: integer;
+      end;
+
+   keyPressDCBGS = record
+      pcount: integer;
+      key: char;
+      modifiers: integer;
+      available: boolean;
+      end;
+      
+   langDCB = record
+      languageNum: integer;
+      end;
+
+   langDCBGS = record
+      pcount: integer;
+      lang: integer;
+      end;
+
+   lInfoDCB = record
+      sFile: pathPtr;
+      dFile: pathPtr;
+      namesList: cStringPtr;
+      iString: cStringPtr;
+      merr: byte;
+      merrf: byte;
+      opFlags: byte;
+      keepFlag: byte;
+      mFlags: longint;
+      pFlags: longint;
+      origin: longint;
+      end;
+
+   getLInfoDCBGS = record
+      pcount: integer;
+      sFile: gsosOutStringPtr;
+      dFile: gsosOutStringPtr;
+      namesList: gsosOutStringPtr;
+      iString: gsosOutStringPtr;
+      merr: byte;
+      merrf: byte;
+      lops: byte;
+      kFlag: byte;
+      mFlags: longint;
+      pFlags: longint;
+      org: longint;
+      end;
+
+   nextWildcardDCB = record
+      nextFile: pathPtr;
+      end;
+
+   nextWildcardDCBGS = record
+      pcount: integer;
+      pathName: gsosOutStringPtr;
+      access: integer;
+      fileType: integer;
+      auxType: longint;
+      storageType: integer;
+      createDate: timeField;
+      modDate: timeField;
+      option: optionListPtr;
+      EOF: longint;
+      blocksUsed: longint;
+      resourceEOF: longint;
+      resourceBlocks: longint;
+      end;
+
+   popVariablesDCBGS = record
+      pcount: integer;
+      end;
+
+   pushVariablesDCBGS = record
+      pcount: integer;
+      end;
+
+   readIndexedDCB = record
+      varName: pStringPtr;
+      value: pStringPtr;
+      index: integer;
+      end;
+
+   readIndexedDCBGS = record
+      pcount: integer;
+      name: gsosOutStringPtr;
+      value: gsosOutStringPtr;
+      index: integer;
+      export: integer;
+      end;
+
+   readKeyDCBGS = record
+      pcount: integer;
+      key: char;
+      modifiers: integer;
+      end;
+
+   readVariableDCB = record
+      varName: pStringPtr;
+      value: pStringPtr;
+      end;
+
+   readVariableDCBGS = record
+      pcount: integer;
+      name: gsosInStringPtr;
+      value: gsosOutStringPtr;
+      export: integer;
+      end;
+
+   redirectDCB = record
+      device: integer;
+      appendFlag: integer;
+      fileName: pStringPtr;
+      end;
+
+   redirectDCBGS = record
+      pcount: integer;
+      device: integer;
+      append: integer;
+      fileName: gsosInStringPtr;
+      end;
+
+   setDCB = record
+      varName: pStringPtr;
+      value: pStringPtr;
+      end;
+
+   setDCBGS = record
+      pcount: integer;
+      name: gsosInStringPtr;
+      value: gsosInStringPtr;
+      export: integer;
+      end;
+
+   setLInfoDCBGS = record
+      pcount: integer;
+      sFile: gsosInStringPtr;
+      dFile: gsosInStringPtr;
+      namesList: gsosInStringPtr;
+      iString: gsosInStringPtr;
+      merr: byte;
+      merrf: byte;
+      lops: byte;
+      kFlag: byte;
+      mFlags: longint;
+      pFlags: longint;
+      org: longint;
+      end;
+
+   stopDCB = record
+      stopFlag: boolean;
+      end;
+
+   stopDCBGS = record
+      pcount: integer;
+      flag: boolean;
+      end;
+
+   unsetVariableDCB = record
+      name: pStringPtr;
+      end;
+
+   unsetVariableDCBGS = record
+      pcount: integer;
+      name: gsosInString;
+      end;
+
+   versionDCB = record
+      version: packed array[1..4] of char;
+      end;
+
+   versionDCBGS = record
+      pcount: integer;
+      version: packed array[1..4] of char;
+      end;
+
+      
+procedure ChangeVector (var parms: changeVectorDCB); prodos ($010C);
+procedure ChangeVectorGS (var parms: changeVectorDCBGS); prodos ($014C);
+
+procedure ConsoleOut (var parms: consoleOutDCB); prodos ($011A);
+procedure ConsoleOutGS (var parms: consoleOutDCBGS); prodos ($015A);
+
+procedure Direction (var parms: directionDCB); prodos ($010F);
+procedure DirectionGS (var parms: directionDCBGS); prodos ($014F);
+
+procedure Error (var parms: errorDCB); prodos ($0105);
+procedure ErrorGS (var parms: errorDCBGS); prodos ($0145);
+
+procedure Execute (var parms: executeDCB); prodos ($010D);
+procedure ExecuteGS (var parms: executeDCBGS); prodos ($014D);
+
+procedure ExpandDevices (var parms: expandDevicesDCB); prodos ($0114);
+procedure ExpandDevicesGS (var parms: expandDevicesDCBGS); prodos ($0154);
+
+procedure Export (var parms: exportDCB); prodos ($0116);
+procedure ExportGS (var parms: exportDCBGS); prodos ($0156);
+
+procedure FastFile (var parms: fastFileDCB); prodos ($010E);
+procedure FastFileGS (var parms: fastFileDCBGS); prodos ($014E);
+
+procedure GetCommand (var parms: getCommandDCB); prodos ($011D);
+procedure GetCommandGS (var parms: getCommandDCBGS); prodos ($015D);
+
+procedure GetIODevices (var parms: IODevicesDCB); prodos ($011C);
+
+procedure Get_Lang (var parms: langDCB); prodos ($0103);
+procedure GetLangGS (var parms: langDCBGS); prodos ($0143);
+
+procedure GetLInfo (var parms: lInfoDCB); prodos ($0101);
+procedure GetLInfoGS (var parms: getLInfoDCBGS); prodos ($0141);
+
+procedure Init_Wildcard (var parms: initWildcardDCB); prodos ($0109);
+procedure InitWildcardGS (var parms: initWildcardDCBGS); prodos ($0149);
+
+procedure KeyPressGS (var parms: keyPressDCBGS); prodos ($015E);
+
+procedure Next_Wildcard (var parms: nextWildcardDCB); prodos ($010A);
+procedure NextWildcardGS (var parms: nextWildcardDCBGS); prodos ($014A);
+
+procedure PopVariables (parms: ptr {pass nil}); prodos ($0117);
+procedure PopVariablesGS (var parms: popVariablesDCBGS); prodos ($0157);
+
+procedure PushVariables (parms: ptr {pass nil}); prodos ($0118);
+procedure PushVariablesGS (var parms: pushVariablesDCBGS); prodos ($0158);
+
+procedure Read_Indexed (var parms: readIndexedDCB); prodos ($0108);
+procedure ReadIndexedGS (var parms: readIndexedDCBGS); prodos ($0148);
+
+procedure ReadKeyGS (var parms: readKeyDCBGS); prodos ($015F);
+
+procedure Read_Variable (var parms: readVariableDCB); prodos ($010B);
+procedure ReadVariableGS (var parms: readVariableDCBGS); prodos ($014B);
+
+procedure Redirect (var parms: directionDCB); prodos ($0110);
+procedure RedirectGS (var parms: directionDCBGS); prodos ($0150);
+
+procedure Set_Variable (var parms: setDCB); prodos ($0106);
+procedure SetGS (var parms: setDCBGS); prodos ($0146);
+
+procedure SetIODevices (var parms: IODevicesDCB); prodos ($011B);
+procedure SetIODevicesGS (var parms: IODevicesDCBGS); prodos ($015B);
+
+procedure Set_Lang (var parms: langDCB); prodos ($0104);
+procedure SetLangGS (var parms: langDCBGS); prodos ($0144);
+
+procedure Set_LInfo (var parms: lInfoDCB); prodos ($0102);
+procedure SetLInfoGS (var parms: setLInfoDCBGS); prodos ($0142);
+
+procedure SetStopFlag (var parms: stopDCB); prodos ($0119);
+procedure SetStopFlagGS (var parms: stopDCBGS); prodos ($0159);
+
+procedure Stop (var parms: stopDCB); prodos ($0113);
+procedure StopGS (var parms: stopDCBGS); prodos ($0153);
+
+procedure UnsetVariable (var parms: unsetVariableDCB); prodos ($0115);
+procedure UnsetVariableGS (var parms: unsetVariableDCBGS); prodos ($0155);
+
+procedure Version (var parms: versionDCB); prodos ($0107);
+procedure VersionGS (var parms: versionDCBGS); prodos ($0147);
+
+implementation
+end.

--- a/Tool.Interface/ObjIntf.pas
+++ b/Tool.Interface/ObjIntf.pas
@@ -1,0 +1,29 @@
+{********************************************************
+*
+*  Object Interface
+*
+*  Other USES Files Needed: - None -
+*
+*  Copyright 1993
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+{$keep 'ObjIntf'}
+
+unit ObjIntf;
+
+interface
+
+type
+   tObject = object
+      function ShallowClone: tObject;
+      function Clone: tObject;
+      procedure ShallowFree;
+      procedure Free;
+      end;
+
+implementation
+
+end.

--- a/Tool.Interface/PrintMgr.pas
+++ b/Tool.Interface/PrintMgr.pas
@@ -1,0 +1,171 @@
+{$keep 'PrintMgr'}
+unit PrintMgr;
+interface
+
+{********************************************************
+*
+*  Print Manager Interface File
+*
+*  Other USES Files Needed:  Common
+*
+*  Other Tool Sets Needed:   Tool Locator, Memory Manager, Miscellaneous
+*                            Tool Set, QuickDraw II, Desk Manager,
+*                            Window Manager, Menu Manager, Control Manager,
+*                            QuickDraw II Auxilliary, LineEdit Tool Set,
+*                            Dialog Manager, Font Manager, List Manager
+*
+*  Copyright 1987-1990
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common;
+
+const
+   (* Printer error codes *)
+   prAbort     =   $80;
+
+type
+   (* Printer information subrecord *)
+   prInfoRec = record
+       iDev:  integer;
+       iVRes: integer;
+       iHRes: integer;
+       rPage: rect;
+       end;
+
+   (* Printer style subrecord *)
+   prStyleRec = record
+       wDev:      integer;
+       internA:   array [0..2] of integer;
+       feed:      integer;
+       paperType: integer;
+       case boolean of
+           true:  (crWidth:   integer;);
+           false: (vSizing:   integer;
+                  reduction: integer;
+                  internB:   integer;);
+           end;
+
+   (* Job information subrecord *)
+   prJobRec = record
+       iFstPage:  integer;
+       iLstPage:  integer;
+       iCopies:   integer;
+       bJDocLoop: byte;
+       fFromUser: byte;
+       pIdleProc: procPtr;
+       pFileName: pathPtr;
+       iFileVol:  integer;
+       bFileVers: byte;
+       bJobX:     byte;
+       end;
+
+   (* Print record *)
+   PrRec = record
+       prVersion: integer;
+       prInfo:    prInfoRec;
+       rPaper:    rect;
+       prStl:     prStyleRec;
+       prInfoPT:  array [0..13] of byte;
+       prXInfo:   array [0..23] of byte;
+       prJob:     PrJobRec;
+       printX:    array [0..37] of byte;
+       iReserved: integer;
+       end;
+   PrRecPtr = ^PrRec;
+   PrHandle = ^PrRecPtr;
+
+   (* Printer status subrecord *)
+   PrStatusRec = record
+       iTotPages:  integer;
+       iCurPage:   integer;
+       iTotCopies: integer;
+       iCurCopy:   integer;
+       iTotBands:  integer;
+       iCurBand:   integer;
+       fPgDirty:   boolean;
+       fImaging:   integer;
+       hPrint:     prHandle;
+       pPrPort:    grafPortPtr;
+       hPic:       longint;
+       end;
+   PrStatusPtr = ^PrStatusRec;
+
+
+procedure PMBootInit; tool ($13, $01);     (* WARNING: an application should
+                                                       NEVER make this call *)
+
+procedure PMStartup (userID, dPageAddr: integer); tool ($13, $02);
+
+procedure PMShutDown; tool ($13, $03);
+
+function PMVersion: integer; tool ($13, $04);
+
+procedure PMReset; tool ($13, $05);        (* WARNING: an application should
+                                                       NEVER make this call *)
+
+function PMStatus: boolean; tool ($13, $06);
+
+procedure PMLoadDriver (driver: integer); tool ($13, $35);
+
+procedure PMUnloadDriver (driver: integer); tool ($13, $34);
+
+function PrChoosePrinter: boolean; tool ($13, $16);
+
+procedure PrCloseDoc (printerPort: grafPortPtr); tool ($13, $0F);
+
+procedure PrClosePage (printerPort: grafPortPtr); tool ($13, $11);
+
+procedure PrDefault (thePrintRecord: prHandle); tool ($13, $09);
+
+function PrDriverVer: integer; tool ($13, $23);
+
+function PrError: integer; tool ($13, $14);
+
+function PrGetDocName: pStringPtr; tool ($13, $36);
+
+function PrGetNetworkName: pStringPtr; tool ($13, $2B);
+
+function PrGetPgOrientation (prRecordHdl: prHandle): integer; tool ($13, $38);
+
+function PrGetPortDvrName: pStringPtr; tool ($13, $29);
+
+function PrGetPrinterDvrName: pStringPtr; tool ($13, $28);
+
+(* PrGetPrinterSpecs returns 2 words:  low word = type of printer         *)
+(*                                    high word = printer characteristics *)
+function PrGetPrinterSpecs: longint; tool ($13, $18);
+
+function PrGetUserName: pStringPtr; tool ($13, $2A);
+
+function PrGetZoneName: pStringPtr; tool ($13, $25);
+
+function PrJobDialog (thePrintRecord: prHandle): boolean; tool ($13, $0C);
+
+function PrOpenDoc (thePrintRecord: prHandle; printerPort: grafPortPtr):
+                    grafPortPtr; tool ($13, $0E);
+
+procedure PrOpenPage (printerPort: grafPortPtr; pageFrame: rectPtr);
+tool ($13, $10);
+
+procedure PrPicFile (thePrintRecord: prHandle; printerPort: grafPortPtr;
+                     statusRecPtr: PrStatusPtr); tool ($13, $12);
+
+procedure PrPixelMap (srcLoc: locInfoPtr; var srcRect: rect; colorFlag: boolean);
+tool($13, $0D);
+
+function PrPortVer: integer; tool ($13, $24);
+
+procedure PrSetDocName (docName: pStringPtr); tool ($13, $37);
+
+procedure PrSetError (errorNumber: integer); tool ($13, $15);
+
+function PrStlDialog (thePrintRecord: prHandle): boolean; tool ($13, $0B);
+
+function PrValidate (thePrintRecord: prHandle): boolean; tool ($13, $0A);
+
+implementation
+end.

--- a/Tool.Interface/ProDOS.pas
+++ b/Tool.Interface/ProDOS.pas
@@ -1,0 +1,267 @@
+{$keep 'ProDOS'}
+unit ProDOS;
+interface
+
+{********************************************************
+*
+*  ProDOS 16 Interface File
+*
+*  Other Uses Files Needed:  Common
+*
+*  Notes:  Each call refers to a data control block (DCB),
+*          defined as a record.  Calls which return values
+*          store the output into the DCB.
+*          All calls return an error number.
+*
+*  Copyright 1987-1990
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common;
+
+type
+   createDCB = record
+       pathName:    pathPtr;
+       access:      integer;
+       fileType:    integer;
+       auxType:     longint;
+       storageType: integer;
+       createDate:  integer;
+       createTime:  integer;
+       end;
+
+   destroyDCB = record
+       pathName: pathPtr;
+       end;
+
+   changePathDCB = record
+       pathName:    pathPtr;
+       newPathName: pathPtr;
+       end;
+
+   setFileInfoDCB = record
+       pathName:   pathPtr;
+       access:     integer;
+       fileType:   integer;
+       auxType:    longint;
+       nullField:  integer;
+       createDate: integer;
+       createTime: integer;
+       modDate:    integer;
+       modTime:    integer;
+       end;
+
+   getFileInfoDCB = record
+       pathName:             pathPtr;
+       access:               integer;
+       fileType:             integer;
+       auxTypeOrTotalBlocks: longint;
+       storageType:          integer;
+       createDate:           integer;
+       createTime:           integer;
+       modDate:              integer;
+       modTime:              integer;
+       blocksUsed:           longint;
+       end;
+
+   volumeDCB = record
+       devName:     pathPtr;
+       volName:     pathPtr;
+       totalBlocks: longint;
+       freeBlocks:  longint;
+       fileSysID:   integer;
+       end;
+
+   prefixDCB = record
+       prefixNum: integer;
+       prefix:    pathPtr;
+       end;
+
+   clrBkupBitDCB = record
+       pathName: pathPtr;
+       end;
+
+   openDCB = record
+       refNum:   integer;
+       pathName: pathPtr;
+       reserved: longint;      (* set this value to $00000000 *)
+       end;
+
+   newlineDCB = record
+       refNum:      integer;
+       enableMask:  integer;
+       newlineChar: integer;
+       end;
+
+   readWriteDCB = record
+       refNum:        integer;
+       dataBuffer:    ptr;
+       requestCount:  longint;
+       transferCount: longint;
+       end;
+
+   closeDCB = record
+       refNum: integer;
+       end;
+
+   flushDCB = record
+       refNum: integer;
+       end;
+
+   markDCB = record
+       refNum:   integer;
+       position: longint;
+       end;
+
+   eofDCB = record
+       refNum:   integer;
+       fileSize: longint;
+       end;
+
+   levelDCB = record
+       level: integer;
+       end;
+
+   dirEntryDCB = record
+       refNum:        integer;
+       flags:         integer;
+       base:          integer;
+       displacement:  integer;
+       name:          ptr;
+       entryNum:      integer;
+       fileType:      integer;
+       eofValue:      longint;
+       blockCount:    longint;
+       createDate:    longint;
+       createTime:    longint;
+       modDate:       longint;
+       modTime:       longint;
+       access:        integer;
+       auxType:       longint;
+       fileSystemID:  integer;
+       end;
+
+   getDevNumDCB = record
+       devName: pathPtr;
+       devNum:  integer;
+       end;
+
+   deviceDCB = record
+       devNum: integer;
+       end;
+
+   blockDCB = record
+       devNum:     integer;
+       dataBuffer: ptr;
+       blockNum:   longint;
+       end;
+
+   formatDCB = record
+       devName:   pathPtr;
+       volName:   pathPtr;
+       fileSysID: integer;
+       end;
+
+   getNameDCB = record
+       theName: pathPtr;
+       end;
+
+   quitDCB = record
+       pathName: pathPtr;
+       flags:    integer;
+       end;
+
+   P16versionDCB = record
+       version: integer;
+       end;
+
+   dInfoDCB = record
+       devNum:   integer;
+       devName:  pathPtr;
+       end;
+
+   allocInterruptDCB = record
+       intNum:  integer;
+       intCode: ptr;
+       end;
+
+   deallocInterruptDCB = record
+       intNum: integer;
+       end;
+
+
+procedure P16Create (var parms: createDCB); prodos ($01);
+
+procedure P16Destroy (var parms: destroyDCB); prodos ($02);
+
+procedure P16Change_Path (var parms: changePathDCB); prodos ($04);
+
+procedure P16Set_File_Info (var parms: setFileInfoDCB); prodos ($05);
+
+procedure P16Get_File_Info (var parms: getFileInfoDCB); prodos ($06);
+
+procedure P16Volume (var parms: volumeDCB); prodos ($08);
+
+procedure P16Set_Prefix (var parms: prefixDCB); prodos ($09);
+
+procedure P16Get_Prefix (var parms: prefixDCB); prodos ($0A);
+
+procedure P16Clear_Backup (var parms: clrBkupBitDCB); prodos ($0B);
+
+procedure P16Open (var parms: openDCB); prodos ($10);
+
+procedure P16Newline (var parms: newlineDCB); prodos ($11);
+
+procedure P16Read (var parms: readWriteDCB); prodos ($12);
+
+procedure P16Write (var parms: readWriteDCB); prodos ($13);
+
+procedure P16Close (var parms: closeDCB); prodos ($14);
+
+procedure P16Flush (var parms: flushDCB); prodos ($15);
+
+procedure P16Set_Mark (var parms: markDCB); prodos ($16);
+
+procedure P16Get_Mark (var parms: markDCB); prodos ($17);
+
+procedure P16Set_EOF (var parms: eofDCB); prodos ($18);
+
+procedure P16Get_EOF (var parms: eofDCB); prodos ($19);
+
+procedure P16Set_Level (var parms: levelDCB); prodos ($1A);
+
+procedure P16Get_Level (var parms: levelDCB); prodos ($1B);
+
+procedure P16Get_Dir_Entry (var parms: dirEntryDCB); prodos ($1C);
+
+procedure P16Get_Dev_Number (var parms: getDevNumDCB); prodos ($20);
+
+procedure P16Get_Last_Dev (var parms: deviceDCB); prodos ($21);
+
+procedure P16Read_Block (var parms: blockDCB); prodos ($22);
+
+procedure P16Write_Block (var parms: blockDCB); prodos ($23);
+
+procedure P16Format (var parms: formatDCB); prodos ($24);
+
+procedure P16Erase_Disk (var parms: formatDCB); prodos ($25);
+
+procedure P16Get_Name (var parms: getNameDCB); prodos ($27);
+
+procedure P16Get_Boot_Vol (var parms: getNameDCB); prodos ($28);
+
+procedure P16Quit (var parms: quitDCB); prodos ($29);
+
+procedure P16Get_Version (var parms: P16versionDCB); prodos ($2A);
+
+procedure P16D_Info (var parms: dInfoDCB); prodos ($2C);
+
+procedure P16Alloc_Interrupt (var parms: allocInterruptDCB); prodos ($31);
+
+procedure P16Dealloc_Interrupt (var parms: deallocInterruptDCB); prodos ($32);
+
+implementation
+end.

--- a/Tool.Interface/QuickDrawII.pas
+++ b/Tool.Interface/QuickDrawII.pas
@@ -1,0 +1,775 @@
+{$keep 'QuickDrawII'}
+unit QuickDrawII;
+interface
+
+{********************************************************
+*
+*  Quick Draw II Interface File
+*
+*  Other USES Files Needed: Common
+*
+*  Other Tool Sets Needed:  Tool Locator, Memory Manager,
+*                           Miscellaneous Tool Set
+*
+*  Note: The calls for the QuickDraw Auxiliary Tool Set
+*       are at the end of this interface file.
+*
+*  Copyright 1987-1992, 1993
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common;
+
+const
+   {Font Flags}
+   widMaxSize      =   $0001;      {nonproportional spacing}
+   zeroSize        =   $0002;      {numeric spacing}
+
+   {Color data}
+   table320        =   $32;        {320 color table}
+   table640        =   $32;        {640 color table}
+
+   {GrafPort sizes}
+   maskSize        =   $08;        {mask size}
+   locSize         =   $10;        {loc size}
+   patSize         =   $20;        {pattern size}
+   pnStateSize     =   $32;        {pen state size}
+   portSize        =   $AA;        {size of grafPort}
+
+   {Color masks}
+   blueMask        =   $000F;      {mask for blue nibble}
+   greenMask       =   $00F0;      {mask for green nibble}
+   redMask         =   $0F00;      {mask for red nibble}
+
+   {Master colors - mode indicated next to name}
+   black           =   $0000;      {works in 320 & 640 modes}
+   blue            =   $000F;      {works in 320 & 640 modes}
+   darkGreen320    =   $0080;
+   green320        =   $00E0;
+   green640        =   $00F0;
+   lightBlue320    =   $04DF;
+   purple320       =   $072C;
+   darkGray320     =   $0777;
+   periwinkleBlue320 = $078F;
+   brown320        =   $0841;
+   lightGray320    =   $0CCC;
+   red320          =   $0D00;
+   lilac320        =   $0DAF;
+   red640          =   $0F00;
+   orange320       =   $0F70;
+   flesh320        =   $0FA9;
+   yellow          =   $0FF0;      {works in 320 & 640 modes}
+   white           =   $0FFF;      {works in 320 & 640 modes}
+
+   {Pen modes}
+   modeCopy        =   $0000;      {copy source to destination}
+   modeOR          =   $0001;      {overlay source & destination}
+   modeXOR         =   $0002;      {XOR pen with destination}
+   modeBIC         =   $0003;      {bit clear pen with destination}
+   notCopy         =   $8000;      {copy (not source) to destination}
+   notOR           =   $8001;      {overlay (not source) & destination}
+   notXOR          =   $8002;      {XOR (not pen) with destination}
+   notBIC          =   $8003;      {bit clear (not pen) with destination}
+
+   {Pen and text modes}
+   modeForeCopy    =   $0004;      {copy foreground pixels to destination}
+   modeForeOR      =   $0005;      {OR foreground pixels into destination}
+   modeForeXOR     =   $0006;      {XOR foreground pixels into destination}
+   modeForeBIC     =   $0007;      {BIC foreground pixels into destination}
+   notForeCopy     =   $8004;      {turn background to foreground, then copy}
+                                   {foreground pixels into destination}
+   notForeOR       =   $8005;      {turn background to foreground, then OR}
+                                   {foreground pixels into destination}
+   notForeXOR      =   $8006;      {turn background to foreground, then XOR}
+                                   {foreground pixels into destination}
+   notForeBIC      =   $8007;      {turn background to foreground, then BIC}
+                                   {foreground pixels into destination}
+
+   {QD Start-up modes}
+   mode320         =   $00;        {320 graphics mode}
+   mode640         =   $80;        {640 graphics mode}
+
+   {SCB Byte Masks}
+   colorTableNo    =   $0F;        {color table number}
+   scbReserved     =   $10;        {reserved for future use}
+   scbFill         =   $20;        {fill mode on}
+   scbInterrupt    =   $40;        {interrupt generated when line refreshed}
+   scbColorMode    =   $80;        {640 mode on}
+
+   {Text styles}
+   boldMask        =   $0001;      {mask for bold bit}
+   italicMask      =   $0002;      {mask for italics bit}
+   underlineMask   =   $0004;      {mask for underline bit}
+   outlineMask     =   $0008;      {mask for outline bit}
+   shadowMask      =   $0010;      {mask for shadow bit}
+
+   {DrawStringWidth flag values}
+   dswNoCondense    = $8000;
+   dswCondense      = $0000;
+   dswNoTruncate    = $0000;
+   dswTruncLeft     = $2000;
+   dswTruncCenter   = $4000;
+   dswTruncRight    = $6000;
+   dswPString       = $0000;
+   dswCString       = $0004;
+   dswWString       = $0008;
+   dswStrIsPtr      = $0000;
+   dswStrIsHandle   = $0001;
+   dswStrIsResource = $0002;
+  
+   {ColorTable flag values}
+   ctUse640Colors   = $8000;
+   ctNoCtlNewRes    = $4000;
+   ctIncludeMenuBar = $2000;
+
+type
+   {QDProcsPointer}
+   QDProcsPtr = ptr;
+
+   {Buffer sizing record}
+   bufDimRec = record
+       maxWidth:        integer;
+       textBufHeight:   integer;
+       textBufferWords: integer;
+       fontWidth:       integer;
+       end;
+
+   {Font globals record}
+   fontGlobalsRecord = record
+       fgFontID:    integer;
+       fgStyle:     integer;
+       fgSize:      integer;
+       fgVersion:   integer;
+       fgWidMax:    integer;
+       fgFBRExtent: integer;
+       end;
+
+   {FontInfo record}
+   fontInfoRecord = record
+       ascent:  integer;
+       descent: integer;
+       widMax:  integer;
+       leading: integer;
+       end;
+
+   {Paint parameter block}
+   paintParamBlock = record
+       ptrToSourceLocInfo:  locInfoPtr;
+       ptrToDestLocInfo:    locInfoPtr;
+       ptrToSourceRect:     rectPtr;
+       ptrToDestPoint:      pointPtr;
+       mode:                integer;
+       maskHandle:          handle;
+       end;
+   paintParamPtr = ^paintParamBlock;
+
+   {Pen state record}
+   penState = record
+       psPnLoc : point;
+       psPnSize:  point;
+       psPnMode:  integer;
+       psPnPat:   pattern;
+       psPnMask:  mask;
+       end;
+   penStatePtr = ^penState;
+
+   {ROM font record}
+   ROMFontRec = record
+       rfFamNum:     integer;
+       rfFamStyle:   integer;
+       rfSize:       integer;
+       rfFontHandle: fontHndl;
+       rfNamePtr:    pStringPtr;
+       rfFBRExtent:  integer;
+       end;
+   ROMFontPtr = ^ROMFontRec;
+
+   {Polygon, defined by user}
+   polygon = record
+       polySize:   integer;
+       polyBBox:   rect;
+       polyPoints: array [0..30] of point;  {may be modified by user}
+       end;
+   polyPtr = ^polygon;
+   polyHandle = ^polyPtr;
+
+   {Cursor record.  Array dimensions can be modified for your cursor.}
+   {WARNING:  hotSpotX, hotSpotY may not be in the location expected, since}
+   {cursorImage and cursorMask can change size.  Use pointer math to}
+   {compute their positions for any cursor you did not define using this}
+   {record.}
+   cursor = record
+       cursorHeight: integer;
+       cursorWidth:  integer;
+       cursorImage:  array [1..44] of integer;
+       cursorMask:   array [1..44] of integer;
+       hotSpotY:     integer;
+       hotSpotX:     integer;
+       end;
+   cursorPtr = ^cursor;
+
+   {QD Auxilliary icon record}
+   iconRec = record
+       iconType:   integer;
+       iconSize:   integer;
+       iconHeight: integer;
+       iconWidth:  integer;
+       iconImage:  array [1..44] of byte;  {Array dimensions can be}
+       iconMask:   array [1..44] of byte;  {modified for your icon}
+       end;
+   iconRecPtr = ^iconRec;
+
+
+procedure QDBootInit; tool ($04, $01);    {WARNING: an application should
+                                                      NEVER make this call}
+
+procedure QDStartup (dPageAddr, masterSCB, maxWidth, userID: integer);
+tool ($04, $02);
+
+procedure QDShutDown; tool ($04, $03);
+
+function QDVersion: integer; tool ($04, $04);
+
+procedure QDReset; tool ($04, $05);       {WARNING: an application should
+                                                    NEVER make this call}
+
+function QDStatus: boolean; tool ($04, $06);
+
+procedure AddPt (var srcPtPtr, destPtPtr: point); tool ($04, $80);
+
+procedure CharBounds (theChar: char; var result: rect); tool ($04, $AC);
+
+function CharWidth (theChar: char): integer; tool ($04, $A8);
+
+procedure ClearScreen (colorWord: integer); tool ($04, $15);
+
+procedure ClipRect (var theRect: rect); tool ($04, $26);
+
+procedure ClosePicture; tool ($04, $B9);
+
+procedure ClosePoly; tool ($04, $C2);
+
+procedure ClosePort (thePort: grafportPtr); tool ($04, $1A);
+
+procedure CloseRgn (theRgnHandle: rgnHandle); tool ($04, $6E);
+
+procedure CopyRgn (srcRgnHandle, destRgnHandle: rgnHandle); tool ($04, $69);
+
+procedure CStringBounds (theCString: univ CStringPtr; var result: rect);
+tool ($04, $AE);
+
+function CStringWidth (theCString: univ CStringPtr): integer; tool ($04, $AA);
+
+procedure DiffRgn (rgn1Handle, rgn2Handle, diffRgnHandle: rgnHandle);
+tool ($04, $73);
+
+procedure DisposeRgn (theRgnHandle: rgnHandle); tool ($04, $68);
+
+procedure DrawChar (theChar: char); tool ($04, $A4);
+
+procedure DrawCString (theString: univ CStringPtr); tool ($04, $A6);
+
+procedure DrawString (theString: univ pStringPtr); tool ($04, $A5);
+
+procedure DrawText (theText: univ textPtr; textLen: integer); tool ($04, $A7);
+
+function EmptyRgn (theRgnHandle: rgnHandle): boolean; tool ($04, $78);
+
+function EqualPt (var point1, point2: point): boolean; tool ($04, $83);
+
+function EqualRect (var rect1, rect2: rect): boolean; tool ($04, $51);
+
+function EqualRgn (rgnHandle1, rgnHandle2: rgnHandle): boolean; tool ($04, $77);
+
+procedure EraseArc (var theRect: rect; startAngle, arcAngle: integer);
+tool ($04, $64);
+
+procedure EraseOval (var theRect: rect); tool ($04, $5A);
+
+procedure ErasePoly (thePolyHandle: polyHandle); tool ($04, $BE);
+
+procedure EraseRect (var theRect: rect); tool ($04, $55);
+
+procedure EraseRgn (theRgnHandle: rgnHandle); tool ($04, $7B);
+
+procedure EraseRRect (var theRect: rect; ovalWidth, ovalHeight: integer);
+tool ($04, $5F);
+
+procedure FillArc (var theRect: rect; startAngle, arcAngle: integer;
+                   var thePattern: pattern); tool ($04, $66);
+
+procedure FillOval (var theRect: rectPtr; var thePattern: pattern);
+tool ($04, $5C);
+
+procedure FillPoly (thePolyHandle: polyHandle; var thePattern: pattern);
+tool ($04, $C0);
+
+procedure FillRect (var theRect: rect; var thePattern: pattern);
+tool ($04, $57);
+
+procedure FillRgn (theRgnHandle: rgnHandle; var thePattern: pattern);
+tool ($04, $7D);
+
+procedure FillRRect (var theRect: rect; ovalWidth, ovalHeight: integer;
+                     var thePattern: pattern); tool ($04, $61);
+
+procedure ForceBufDims (maxWidth, maxFontHeight, maxFBRExtent: integer);
+tool ($04, $CC);
+
+procedure FrameArc (var theRect: rect; startAngle, arcAngle: integer);
+tool ($04, $62);
+
+procedure FrameOval (var theRect: rect); tool ($04, $58);
+
+procedure FramePoly (thePolyHandle: polyHandle); tool ($04, $BC);
+
+procedure FrameRect (var theRect: rect); tool ($04, $53);
+
+procedure FrameRgn (theRgnHandle: rgnHandle); tool ($04, $79);
+
+procedure FrameRRect (var theRect: rect; ovalWidth, ovalHeight: integer);
+tool ($04, $5D);
+
+function Get640Colors: patternPtr; tool ($04, $DA);
+
+function GetAddress (tableID: integer): ptr; tool ($04, $09);
+
+function GetArcRot: integer; tool ($04, $B1);
+
+function GetBackColor: integer; tool ($04, $A3);
+
+procedure GetBackPat (var thePattern: pattern); tool ($04, $35);
+
+function GetCharExtra: fixed; tool ($04, $D5);
+
+procedure GetClip (theRgnHandle: rgnHandle); tool ($04, $25);
+
+function GetClipHandle: rgnHandle; tool ($04, $C7);
+
+function GetColorEntry (tableNumber, entryNumber: integer): integer;
+tool ($04, $11);
+
+procedure GetColorTable (tableNumber: integer; var saveTable: colorTable);
+tool ($04, $0F);
+
+function GetCursorAdr: cursorPtr; tool ($04, $8F);
+
+function GetFGSize: integer; tool ($04, $CF);
+
+function GetFont: fontHndl; tool ($04, $95);
+
+function GetFontFlags: integer; tool ($04, $99);
+
+procedure GetFontGlobals (var theFGRec: fontGlobalsRecord); tool ($04, $97);
+
+function GetFontID: longint; tool ($04, $D1);
+
+procedure GetFontInfo (var theFIRec: fontInfoRecord); tool ($04, $96);
+
+function GetFontLore (recordPtr: ptr; recordSize: integer): integer;
+tool ($04, $D9);
+
+function GetForeColor: integer; tool ($04, $A1);
+
+function GetGrafProcs: QDProcsPtr; tool ($04, $45);
+
+function GetMasterSCB: integer; tool ($04, $17);
+
+procedure GetPen (var thePoint: point); tool ($04, $29);
+
+procedure GetPenMask (var theMask: mask); tool ($04, $33);
+
+function GetPenMode: integer; tool ($04, $2F);
+
+procedure GetPenPat (var thePattern: pattern); tool ($04, $31);
+
+procedure GetPenSize (var thePoint: point); tool ($04, $2D);
+
+procedure GetPenState (var oldPenState: penState); tool ($04, $2B);
+
+function GetPicSave: handle; tool ($04, $3F);
+
+function GetPixel (h, v: integer): integer; tool ($04, $88);
+
+function GetPolySave: handle; tool ($04, $43);
+
+function GetPort: grafPortPtr; tool ($04, $1C);
+
+procedure GetPortLoc (var theLocInfo: locInfo); tool ($04, $1E);
+
+procedure GetPortRect (var theRect: rect); tool ($04, $20);
+
+function GetRgnSave: handle; tool ($04, $41);
+
+procedure GetROMFont (var recordPtr: ROMFontRec); tool ($04, $D8);
+
+function GetSCB (scanLine: integer): integer; tool ($04, $13);
+
+function GetSpaceExtra: fixed; tool ($04, $9F);
+
+function GetStandardSCB: integer; tool ($04, $0C);
+
+function GetSysField: longint; tool ($04, $49);
+
+function GetSysFont: fontHndl; tool ($04, $B3);
+
+function GetTextFace: integer; tool ($04, $9B);
+
+function GetTextMode: integer; tool ($04, $9D);
+
+function GetTextSize: integer; tool ($04, $D3);
+
+function GetUserField: longint; tool ($04, $47);
+
+function GetVisHandle: rgnHandle; tool ($04, $C9);
+
+procedure GetVisRgn (theRgnHandle: rgnHandle); tool ($04, $B5);
+
+procedure GlobalToLocal (var thePoint: point); tool ($04, $85);
+
+procedure GrafOff; tool ($04, $0B);
+
+procedure GrafOn; tool ($04, $0A);
+
+procedure HideCursor; tool ($04, $90);
+
+procedure HidePen; tool ($04, $27);
+
+procedure InflateTextBuffer (newWidth, newHeight: integer); tool ($04, $D7);
+
+procedure InitColorTable (var theTable: colorTable); tool ($04, $0D);
+
+procedure InitCursor; tool ($04, $CA);
+
+procedure InitPort (thePort: grafportPtr); tool ($04, $19);
+
+procedure InsetRect (var theRect: rect; dH, dV: integer); tool ($04, $4C);
+
+procedure InsetRgn (theRgnHandle: rgnHandle; dH, dV: integer); tool ($04, $70);
+
+procedure InvertArc (var theRect: rect; startAngle, arcAngle: integer);
+tool ($04, $65);
+
+procedure InvertOval (var theRect: rect); tool ($04, $5B);
+
+procedure InvertPoly (thePolyHandle: polyHandle); tool ($04, $BF);
+
+procedure InvertRect (var theRect: rect); tool ($04, $56);
+
+procedure InvertRgn (theRgnHandle: rgnHandle); tool ($04, $7C);
+
+procedure InvertRRect (var theRect: rect; ovalWidth, ovalHeight: integer);
+tool ($04, $60);
+
+procedure KillPoly (thePolyHandle: polyHandle); tool ($04, $C3);
+
+procedure Line (dH, dV: integer); tool ($04, $3D);
+
+procedure LineTo (h, v: integer); tool ($04, $3C);
+
+procedure LocalToGlobal (var thePoint: point); tool ($04, $84);
+
+procedure MapPoly (thePoly: polyHandle; var srcRect, destRect: rect);
+tool ($04, $C5);
+
+procedure MapPt (var thePoint: point; var srcRect, destRect: rect);
+tool ($04, $8A);
+
+procedure MapRect (var theRect, srcRect, destRect: rect); tool ($04, $8B);
+
+procedure MapRgn (mapRgnHandle: rgnHandle; var srcRect, destRect: rect);
+tool ($04, $8C);
+
+procedure Move (dH, dV: integer); tool ($04, $3B);
+
+procedure MovePortTo (h, v: integer); tool ($04, $22);
+
+procedure MoveTo (h, v: integer); tool ($04, $3A);
+
+function NewRgn: rgnHandle; tool ($04, $67);
+
+function NotEmptyRect (var theRect: rect): boolean; tool ($04, $52);
+
+procedure ObscureCursor; tool ($04, $92);
+
+procedure OffsetPoly (thePolyHandle: polyHandle; dH, dV: integer); tool ($04, $C4);
+
+procedure OffsetRect (var theRect: rect; dH, dV: integer); tool ($04, $4B);
+
+procedure OffsetRgn (theRgnHandle: rgnHandle; dH, dV: integer); tool ($04, $6F);
+
+function OpenPoly: polyHandle; tool ($04, $C1);
+
+procedure OpenPort (newPort: grafportPtr); tool ($04, $18);
+
+procedure OpenRgn; tool ($04, $6D);
+
+procedure PaintArc (var theRect: rect; startAngle, arcAngle: integer);
+tool ($04, $63);
+
+procedure PaintOval (var theRect: rect); tool ($04, $59);
+
+procedure PaintPixels (var thePaintParam: paintParamBlock); tool ($04, $7F);
+
+procedure PaintPoly (thePolyHandle: polyHandle); tool ($04, $BD);
+
+procedure PaintRect (var theRect: rect); tool ($04, $54);
+
+procedure PaintRgn (theRgnHandle: rgnHandle); tool ($04, $7A);
+
+procedure PaintRRect (var theRect: rect; ovalWidth, ovalHeight: integer);
+tool ($04, $5E);
+
+procedure PenNormal; tool ($04, $36);
+
+procedure PPToPort (srcLoc: locInfoPtr; var srcRect: rect; destX,
+                    destY, transferMode: integer); tool ($04, $D6);
+
+procedure Pt2Rect (var point1, point2: point; var destRect: rect);
+tool ($04, $50);
+
+function PtInRect (var thePoint: point; var theRect: rect): boolean;
+tool ($04, $4F);
+
+function PtInRgn (var thePoint: point; theRgnHandle: rgnHandle): boolean;
+tool ($04, $75);
+
+function QDRandom: integer; tool ($04, $86);
+
+function RectInRgn (var theRect: rect; theRgnHandle: rgnHandle): boolean;
+tool ($04, $76);
+
+procedure RectRgn (theRgnHandle: rgnHandle; var theRect: rect); tool ($04, $6C);
+
+procedure RestoreBufDims (var saveSizeInfo: bufDimRec); tool ($04, $CE);
+
+procedure SaveBufDims (var saveSizeInfo: bufDimRec); tool ($04, $CD);
+
+procedure ScalePt (var thePoint: point; var srcRect, destRect: rect);
+tool ($04, $89);
+
+procedure ScrollRect (var theRect: rect; dH, dV: integer; updateRgnHandle:
+                      rgnHandle); tool ($04, $7E);
+
+function SectRect (var rect1, rect2, destRect: rect): boolean;
+tool ($04, $4D);
+
+procedure SectRgn (rgn1Handle, rgn2Handle, destRgnHandle: rgnHandle);
+tool ($04, $71);
+
+procedure Set640Colors (colorNum: integer); tool ($04, $DB);
+{Set640Color is correct; Set640Colors is retained for backwards compatibility}
+procedure Set640Color (colorNum: integer); tool ($04, $DB);
+
+procedure SetAllSCBs (newSCB: integer); tool ($04, $14);
+
+procedure SetArcRot (arcRotValue: integer); tool ($04, $B0);
+
+procedure SetBackColor (backColor: integer); tool ($04, $A2);
+
+procedure SetBackPat (var thePattern: pattern); tool ($04, $34);
+
+procedure SetBufDims (maxWidth, maxFontHeight, maxFBRExtent: integer);
+tool ($04, $CB);
+
+procedure SetCharExtra (charExtra: fixed); tool ($04, $D4);
+
+procedure SetClip (rgnHandle: handle); tool ($04, $24);
+
+procedure SetClipHandle (clipRgnHandle: rgnHandle); tool ($04, $C6);
+
+procedure SetColorEntry (tableNumber, entryNumber, newColor: integer);
+tool ($04, $10);
+
+procedure SetColorTable (tableNumber: integer; var newTable: colorTable);
+tool ($04, $0E);
+
+procedure SetCursor (var theCursor: cursor); tool ($04, $8E);
+
+procedure SetEmptyRgn (theRgnHandle: rgnHandle); tool ($04, $6A);
+
+procedure SetFont (newFontHandle: fontHndl); tool ($04, $94);
+
+procedure SetFontFlags (fontFlags: integer); tool ($04, $98);
+
+procedure SetFontID (newFontID: fontID); tool ($04, $D0);
+
+procedure SetForeColor (foreColor: integer); tool ($04, $A0);
+
+procedure SetGrafProcs (grafProcsPtr: ptr); tool ($04, $44);
+
+procedure SetIntUse (useInt: boolean); tool ($04, $B6);
+
+procedure SetMasterSCB (masterSCB: integer); tool ($04, $16);
+
+procedure SetOrigin (h, v: integer); tool ($04, $23);
+
+procedure SetPenMask (var theMask: mask); tool ($04, $32);
+
+procedure SetPenMode (penMode: integer); tool ($04, $2E);
+
+procedure SetPenPat (var thePattern: pattern); tool ($04, $30);
+
+procedure SetPenSize (width, height: integer); tool ($04, $2C);
+ 
+procedure SetPenState (var newPenState: penState); tool ($04, $2A);
+
+procedure SetPicSave (picSaveValue: handle); tool ($04, $3E);
+{WARNING: an application should
+            NEVER make this call}
+
+procedure SetPolySave (polySaveValue: handle); tool ($04, $42);
+{WARNING: an application should
+            NEVER make this call}
+
+procedure SetPort (thePort: grafportPtr); tool ($04, $1B);
+
+procedure SetPortLoc (var theLocInfo: locInfo); tool ($04, $1D);
+
+procedure SetPortRect (var theRect: rect); tool ($04, $1F);
+
+procedure SetPortSize (portWidth, portHeight: integer); tool ($04, $21);
+
+procedure SetPt (var srcPoint: point; h, v: integer); tool ($04, $82);
+
+procedure SetRandSeed (randomSeed: longint); tool ($04, $87);
+
+procedure SetRect (var theRect: rect; left, top, right, bottom: integer);
+tool ($04, $4A);
+
+procedure SetRectRgn (theRgnHandle: rgnHandle; left, top, right, bottom:
+                      integer); tool ($04, $6B);
+
+procedure SetRgnSave (rgnSaveValue: handle); tool ($04, $40);
+{WARNING: an application should
+            NEVER make this call}
+
+procedure SetSCB (scanLine, newSCB: integer); tool ($04, $12);
+
+procedure SetSolidBackPat (colorNum: integer); tool ($04, $38);
+
+procedure SetSolidPenPat (colorNum: integer); tool ($04, $37);
+
+procedure SetSpaceExtra (spaceExtra: fixed); tool ($04, $9E);
+
+procedure SetStdProcs (stdProcRecPtr: QDProcsPtr); tool ($04, $8D);
+
+procedure SetSysField (sysFieldValue: longint); tool ($04, $48);
+{WARNING: an application should
+            NEVER make this call}
+
+procedure SetSysFont (theFontHandle: fontHndl); tool ($04, $B2);
+
+procedure SetTextFace (textFace: integer); tool ($04, $9A);
+
+procedure SetTextMode (textMode: integer); tool ($04, $9C);
+
+procedure SetTextSize (textSize: integer); tool ($04, $D2);
+
+procedure SetUserField (userFieldValue: longint); tool ($04, $46);
+
+procedure SetVisHandle (theRgnHandle: rgnHandle); tool ($04, $C8);
+
+procedure SetVisRgn (theRgnHandle: rgnHandle); tool ($04, $B4);
+
+procedure ShowCursor; tool ($04, $91);
+
+procedure ShowPen; tool ($04, $28);
+
+procedure SolidPattern (colorNum: integer; var thePattern: pattern);
+tool ($04, $39);
+
+procedure StringBounds (theString: univ pStringPtr; var theRect: rect);
+tool ($04, $AD);
+
+function StringWidth (theString: univ pStringPtr): integer; tool ($04, $A9);
+
+procedure SubPt (var srcPoint, destPoint: point); tool ($04, $81);
+
+procedure TextBounds (theText: univ textPtr; textLen: integer;
+                      var theRect: rect); tool ($04, $AF);
+
+function TextWidth (theText: univ textPtr; textLen: integer): integer;
+tool ($04, $AB);
+
+procedure UnionRect (var rect1, rect2, destRect: rect); tool ($04, $4E);
+
+procedure UnionRgn (rgn1Handle, rgn2Handle, destRgnHandle: rgnHandle);
+tool ($04, $72);
+
+procedure XorRgn (rgn1Handle, rgn2Handle, destRgnHandle: rgnHandle);
+tool ($04, $74);
+
+{------------------------ QuickDraw Auxiliary Tool Set --------------------}
+
+procedure QDAuxBootInit; tool ($12, $01);   {WARNING: an application should
+                                                        NEVER make this call}
+procedure QDAuxStartup; tool ($12, $02);
+
+procedure QDAuxShutDown; tool ($12, $03);
+
+function QDAuxVersion: integer; tool ($12, $04);
+
+procedure QDAuxReset; tool ($12, $05);      {WARNING: an application should
+                                                        NEVER make this call}
+
+function QDAuxStatus: boolean; tool ($12, $06);
+
+procedure CalcMask (var srcLocInfo: locInfo; var srcRect: rect;
+                    var destLocInfo: locInfo; var destRect: rect;
+                    resMode: integer; thePattern: patternPtr;
+                    leakTblPtr: univ ptr); tool ($12, $0E);
+      
+procedure CopyPixels (var srcLocPtr, destLocPtr: locInfo;
+                      var srcRect, destRect: rect;
+                      xFerMode: integer; maskRgn: rgnHandle); tool ($12, $09);
+
+procedure DrawIcon (var iconPtr: iconRec; displayMode, xPos, yPos: integer);
+tool ($12, $0B);
+
+procedure DrawPicture (picHandle: handle; var destRect: rect); tool ($04, $BA);
+
+function GetSysIcon (flags, value: integer; auxValue: longint): ptr;
+tool ($12, $0F);
+
+procedure IBeamCursor; tool ($12, $13);
+
+procedure KillPicture (picHandle: handle); tool ($04, $BB);
+
+function OpenPicture (var picFrame: rect): handle; tool ($04, $B7);
+
+procedure PicComment (commentKind, dataSize: integer; dataHandle: handle);
+tool ($04, $B8);
+
+function PixelMap2Rgn (srcLocInfo: locInfo; flags, colorsToInclude: integer):
+   rgnHandle; tool ($12, $10);
+
+procedure SeedFill (var srcLocInfoPtr: locInfo; var srcRect: rect;
+                    var destLocInfoPtr: locInfo; var destRec: rect;
+                    seedH, seedV, resMode: integer; thePattern: patternPtr;
+                    leakTblPtr: univ ptr); tool ($12, $0D);
+
+procedure SpecialRect (var theRect: rect; frameColor, fillColor: integer);
+tool ($12, $0C);
+
+procedure WaitCursor; tool ($12, $0A);
+
+procedure WhooshRect (flags: longint; smallRect, bigRect: rect);
+tool ($12, $14);
+
+{new in 6.0.1}
+
+procedure DrawStringWidth (flags: integer; stringRef: univ longint;
+                           width: integer); tool ($12, $15);
+
+function UseColorTable (tableNum: integer; table: colorTablePtr;
+                        flags:integer): handle; tool ($12, $16);
+
+procedure RestoreColorTable (colorInfoHandle: handle; flags: integer);
+tool ($12, $17);
+
+implementation
+end.

--- a/Tool.Interface/ResourceMgr.pas
+++ b/Tool.Interface/ResourceMgr.pas
@@ -1,0 +1,241 @@
+{$keep 'ResourceMgr'}
+unit ResourceMgr;
+interface
+
+{********************************************************
+*
+*  Resource Manager Interface File
+*
+*  Other USES files needed:  Common
+*
+*  Other Tool Sets Needed:  - None -
+*
+*  Copyright 1987-1992, 1993
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common;
+
+const
+   (* Resource Manager Error Codes *)
+   resForkUsed     =   $1E01;  (* resource fork not empty                     *)
+   resBadFormat    =   $1E02;  (* format of resource fork is unknown          *)
+   resNoConverter  =   $1E03;  (* no converter logged in for resource         *)
+   resNoCurFile    =   $1E04;  (* there are no current open resource files    *)
+   resDupID        =   $1E05;  (* ID is already used                          *)
+   resNotFound     =   $1E06;  (* resource was not found                      *)
+   resFileNotFound =   $1E07;  (* resource file not found                     *)
+   resBadAppID     =   $1E08;  (* user ID not found, call ResourceStartup     *)
+   resNoUniqueID   =   $1E09;  (* a unique ID was not found                   *)
+   resIndexRange   =   $1E0A;  (* index is out of range                       *)
+   resSysIsOpen    =   $1E0B;  (* system file is already open                 *)
+   resHasChanged   =   $1E0C;  (* resource changed - operation can't be done  *)
+   resDifConverter =   $1E0D;  (* different converter logged for resrc type   *)
+
+   (* Resource flag values *)
+   resChanged      =   $0020;  (* true if resource has changed                *)
+   resPreLoad      =   $0040;  (* true if should load with OpenResourceFile   *)
+   resProtected    =   $0080;  (* true if should never write to disk          *)
+   resAbsLoad      =   $0400;  (* true if should load at absolute address     *)
+   resConverter    =   $0800;  (* true if requires converter for loads/writes *)
+   resMemAttr      =   $C31C;  (* mask for NewHandle for resource memory      *)
+
+   (* System file ID *)
+   sysFileID       =   $0001;  (* file ID of system resource file *)
+
+   (* Map flag values *)
+   systemMap       =   $0001;
+   mapChanged      =   $0002;  (* true if map has changed         *)
+   romMap          =   $0004;  (* true if resource file is in ROM *)
+
+type
+   resID   = longint;
+   resType = integer;
+   resAttr = integer;
+
+   resHeaderRec = record
+       rFileVersion:  longint;
+       rFileToMap:    longint;
+       rFileMapSize:  longint;
+       rFileMemo:     packed array [1..128] of byte;
+       end;
+
+   freeBlockRec = record
+       blkOffset:  longint;
+       blkSize:    longint;
+       end;
+
+   resRefRec = record
+       rResType:    resType;
+       rResID:      resID;
+       rResOffset:  longint;
+       rResAttr:    resAttr;
+       rResSize:    longint;
+       rResHandle:  handle;
+       end;
+
+   resMapHandle = ^resMapPtr;
+   resMapPtr    = ^resMapRec;
+   resMapRec = record
+       mapNext:          resMapHandle;
+       mapFlag:          integer;
+       mapOffset:        longint;
+       mapSize:          longint;
+       mapToIndex:       integer;
+       mapFileNum:       integer;
+       mapID:            integer;
+       mapIndexSize:     longint;
+       mapIndexUsed:     longint;
+       mapFreeListSize:  integer;
+       mapFreeListUsed:  integer;
+   (* Set the array size for your application. *)
+       mapFreeList:      array [1..1] of freeBlockRec;
+       end;
+
+   resourceSpec = record
+       resourceType:  resType;
+       resourceID:    resID;
+       end;
+
+   resNameEntryPtr = ^resNameEntry;
+   resNameEntry = record
+       namedResID:  resID;
+       resName:     pString
+       end;
+
+   resNameRecordHandle = ^ResNameRecordPtr;
+   resNameRecordPtr    = ^ResNameRecord;
+   resNameRecord = record
+       version:         integer;
+       nameCount:       longint;
+       resNameEntries:  array [1..1] of resNameEntry;
+       end;
+
+
+procedure ResourceBootInit; tool ($1E, $01); (* WARNING: an application should
+                                                         NEVER make this call *)
+
+procedure ResourceStartup (myID: integer); tool ($1E, $02);
+
+procedure ResourceShutdown; tool ($1E, $03);
+
+function ResourceVersion: integer; tool ($1E, $04);
+
+procedure ResourceReset; tool ($1E, $05);    (* WARNING: an application should
+                                                         NEVER make this call *)
+
+function ResourceStatus: boolean; tool ($1E, $06);
+
+procedure AddResource (resourceHandle: handle; resourceAttr: integer;
+                       resourceType: integer; resourceID: longint);
+tool ($1E, $0C);
+
+procedure CloseResourceFile (fileID: integer); tool ($1E, $0B);
+
+function CountResources (resourceType: integer): longint; tool ($1E, $22);
+
+function CountTypes: integer; tool ($1E, $20);
+
+procedure CreateResourceFile (auxType: longint; fileType: integer; 
+                              fileAccess: integer; var fileName: gsosInString);
+tool ($1E, $09);
+
+procedure DetachResource (resourceType: integer; resourceID: longint); 
+tool ($1E, $18);
+
+function GetCurResourceApp: integer; tool ($1E, $14);
+
+function GetCurResourceFile: integer; tool ($1E, $12);
+
+function GetIndResource (resourceType: resType; resourceIndex: longint): resID;
+tool ($1E, $23);
+
+function GetIndType (typeIndex: integer): resType; tool ($1E, $21);
+
+function GetMapHandle (fileID: integer): resMapHandle; tool ($1E, $26);
+
+function GetOpenFileRefNum (fileID: integer): integer; tool ($1E, $1F);
+
+function GetResourceAttr (resourceType: resType; resourceID: resID): resAttr;
+tool ($1E, $1B);
+
+function GetResourceSize (resourceType: resType; resourceID: resID): longint;
+tool ($1E, $1D);
+
+function HomeResourceFile (resourceType: resType; resourceID: resID): integer;
+tool ($1E, $15);
+
+function LoadAbsResource (loadAddress: longint; maxSize: longint;
+                          resourceType: resType; resourceID: resID): longint;
+tool ($1E, $27);
+
+function LoadResource (resourceType: resType; resourceID: resID): handle;
+tool ($1E, $0E);
+
+function LoadResource2 (flags: integer; buffer: ptr; resourceType: resType;
+   resourceID: resID): handle; tool ($1E, $29);
+
+procedure MarkResourceChange (changeFlag: boolean; resourceType: resType;
+                              resourceID: resID); tool ($1E, $10);
+
+procedure MatchResourceHandle (var foundRec: resourceSpec;
+                               resourceHandle: handle); tool ($1E, $1E);
+
+function OpenResourceFile (openAccess: integer; mapAddress: resMapPtr;
+                           var fileName: gsosInString): integer; tool ($1E, $0A);
+
+procedure ReleaseResource (purgeLevel: integer; resourceType: resType;
+                           resourceID: resID); tool ($1E, $17);
+
+procedure RemoveResource (resourceType: resType; resourceID: resID);
+tool ($1E, $0F);
+
+procedure ResourceConverter (converterProc: procPtr; resourceType: resType;
+                             logFlags: integer); tool ($1E, $28);
+
+function RMFindNamedResource (resourceType: resType; name: pString;
+   var fileNum: integer): longint; tool ($1E, $2A);
+
+procedure RMGetResourceName (resourceType: resType; rID: longint;
+   var name: pString); tool ($1E, $2B);
+
+procedure RMSetResourceName (resourceType: resType; rID: longint;
+   name: pString); tool ($1E, $2D);
+
+function RMLoadNamedResource (resourceType: resType; name: pString):
+   handle; tool ($1E, $2C);
+
+procedure SetCurResourceApp (myID: integer); tool ($1E, $13);
+
+procedure SetCurResourceFile (fileID: integer); tool ($1E, $11);
+
+procedure SetResourceAttr (resourceAttr: resAttr; resourceType: resType;
+                           resourceID: resID); tool ($1E, $1C);
+
+function SetResourceFileDepth (searchDepth: integer): integer; tool ($1E, $25);
+
+procedure SetResourceID (newID: resID; resourceType: resType; 
+                         currentID: resID); tool ($1E, $1A);
+
+function SetResourceLoad (readFlag: integer): integer; tool ($1E, $24);
+
+function UniqueResourceID (IDrange: integer; resourceType: resType): resID;
+tool ($1E, $19);
+
+procedure UpdateResourceFile (fileID: integer); tool ($1E, $0D);
+
+procedure WriteResource (resourceType: resType; resourceID: resID);
+tool ($1E, $16);
+
+{new in 6.0.1}
+
+function OpenResourceFileByID (openAccess, userID: integer): integer;
+tool ($1E, $2E);
+
+procedure CompactResourceFile (flags, fileID: integer); tool ($1E, $2F);
+
+implementation
+end.

--- a/Tool.Interface/SFToolSet.pas
+++ b/Tool.Interface/SFToolSet.pas
@@ -1,0 +1,148 @@
+{$keep 'SFToolSet'}
+unit SFToolSet;
+interface
+
+{********************************************************
+*
+*   Standard File Operations Tool Set Interface File
+*
+*   Other USES Files Needed: Common, Dialog Manager
+*
+*   Other Tool Sets Needed:  Tool Locator, Memory Manager,
+*                            Miscellaneous Tool Set, QuickDraw II,
+*                            Event Manager, Window Manager, Control Manager,
+*                            Menu Manager, LineEdit Tool Set, Dialog Manager
+*
+*  Copyright 1987-1990
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common, DialogMgr;
+
+const
+   (* Filter procedure results. *)
+   noDisplay       =   $0000;      (* don't display file                      *)
+   noSelect        =   $0001;      (* display file, but don't allow selection *)
+   displaySelect   =   $0002;      (* display file and allow selection        *)
+
+type
+   typeList = record
+       numEntries: byte;
+       fileType:   array [1..10] of byte;    (* Array can be expanded *)
+       end;
+   typeListPtr = ^typeList;
+
+   replyRecord = record
+       good:         boolean;
+       fileType:     integer;
+       auxFileType:  integer;
+       fileName:     packed array [0..15] of char;
+       fullPathName: pathName;
+       end;
+
+   replyRecord5_0 = record
+       good:         integer;
+       fileType:     integer;
+       auxFileType:  longint;
+       nameVerb:     integer;
+       nameRef:      longint;
+       pathVerb:     integer;
+       pathRef:      longint;
+       end;
+
+   typeRec = record
+       flags:     integer;
+       fileType:  integer;
+       auxType:   longint;
+       end;
+
+   typeList5_0 = record
+       numEntries:       integer;
+       fileAndAuxTypes:  array [1..10] of typeRec;     (* change array size *)
+       end;                                            (*   as needed       *)
+   typeList5_0Ptr = ^typeList5_0;
+
+   multiReplyRecord = record
+      good:         integer;
+      namesHandle:  handle;
+      end;   
+
+
+procedure SFBootInit; tool ($17, $01);     (* WARNING: an application should
+                                                       NEVER make this call *)
+
+procedure SFStartup (userID, dPageAddr: integer); tool ($17, $02);
+
+procedure SFShutDown; tool ($17, $03);
+
+function SFVersion: integer; tool ($17, $04);
+
+procedure SFReset; tool ($17, $05);        (* WARNING: an application should
+                                                       NEVER make this call *)
+
+function SFStatus: boolean; tool ($17, $06);
+
+procedure SFAllCaps (allCapsFlag: boolean); tool ($17, $0D);
+
+procedure SFGetFile (whereX, whereY: integer; prompt: univ pStringPtr;
+                     filterProc: procPtr; theTypeList: typeListPtr;
+                     var theReply: replyRecord); tool ($17, $09);
+
+procedure SFGetFile2 (whereX, whereY, promptVerb: integer;
+                      promptRef: univ longint; filterProcPtr: procPtr;
+                      var theTypeList: typeList5_0;
+                      var theReply: replyRecord5_0); tool ($17, $0E);
+
+procedure SFMultiGet2 (whereX, whereY, promptVerb: integer;
+                       promptRef: univ longint; filterProcPtr: procPtr;
+                       var theTypeList: typeList5_0;
+                       var theReply: multiReplyRecord); tool ($17, $14);
+       
+procedure SFPGetFile (whereX, whereY: integer; prompt: univ pStringPtr;
+                      filterProc: procPtr; theTypeList: typeListPtr;
+                      theDialogTemplate: dialogTempPtr; dialogHookPtr: procPtr;
+                      var theReply: replyRecord); tool ($17, $0B);
+
+procedure SFPGetFile2 (whereX, whereY: integer; itemDrawPtr: procPtr;
+                       promptVerb: integer; promptRef: univ longint;
+                       filterProcPtr: procPtr; var theTypeList: typeList5_0;
+                       var dlgTemp: dialogTemplate; dialogHookPtr: procPtr;
+                       var theReply: replyRecord5_0); tool ($17, $10);
+
+procedure SFPMultiGet2 (whereX, whereY: integer; itemDrawPtr: procPtr;
+                        promptVerb: integer; promptRef: univ longint;
+                        filterProcPtr: procPtr;
+                        var theTypeList: typeList5_0;
+                        var dlgTemp: dialogTemplate; dialogHookPtr: procPtr;
+                        var theReply: multiReplyRecord); tool ($17, $15);
+       
+procedure SFPPutFile (whereX, whereY: integer; prompt, origName: univ pStringPtr;
+                      maxLen: integer; theDialogTemplate: dialogTempPtr;
+                      dialogHookPtr: procPtr; var theReply: replyRecord);
+                      tool ($17, $0C);
+
+procedure SFPPutFile2 (whereX, whereY: integer; itemDrawPtr: procPtr;
+                       promptVerb: integer; promptRef: univ longint;
+                       origNameVerb: integer; origNameRef:  univ longint;
+                       var dlgTemp: dialogTemplate; dialogHookPtr: procPtr;
+                       var theReply: replyRecord5_0); tool ($17, $11);
+       
+procedure SFPutFile (whereX, whereY: integer; prompt, origName: univ pStringPtr;
+                     maxLen: integer; var theReply: replyRecord);
+                     tool ($17, $0A);
+
+procedure SFPutFile2 (whereX, whereY, promptVerb: integer;
+                      promptRef: univ longint; origNameVerb: integer;
+                      origNameRef: univ longint;
+                      var theReply: replyRecord5_0); tool ($17, $0F);
+            
+procedure SFReScan (filterProcPtr: procPtr; var theTypeList: typeList);
+tool ($17, $13);
+
+function SFShowInvisible (invisibleState: boolean): boolean; tool ($17, $12);
+
+implementation
+end.

--- a/Tool.Interface/Scheduler.pas
+++ b/Tool.Interface/Scheduler.pas
@@ -1,0 +1,45 @@
+{$keep 'Scheduler'}
+unit Scheduler;
+interface
+
+{********************************************************
+*
+*  Scheduler Tool Set Interface File
+*
+*  Other USES Files Needed:  Common
+*
+*  Other Tool Sets Needed:   Tool Locator
+*
+*  Copyright 1987-1990
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common;
+
+
+procedure SchBootInit; tool ($07, $01);    (* WARNING: an application should
+                                                       NEVER make this call *)
+
+procedure SchStartup; tool ($07, $02);
+
+procedure SchShutDown; tool ($07, $03);
+
+function SchVersion: integer; tool ($07, $04);
+
+procedure SchReset; tool ($07, $05);       (* WARNING: an application should
+                                                       NEVER make this call *)
+
+function SchStatus: boolean; tool ($07, $06);
+
+function SchAddTask (theTask: procPtr): integer; tool ($07, $09);
+
+procedure SchFlush; tool ($07, $0A);       (* WARNING: an application should
+                                                       NEVER make this call *)
+
+
+implementation
+
+end.

--- a/Tool.Interface/ScrapMgr.pas
+++ b/Tool.Interface/ScrapMgr.pas
@@ -1,0 +1,83 @@
+{$keep 'ScrapMgr'}
+unit ScrapMgr;
+interface
+
+{********************************************************
+*
+*  Scrap Manager Interface File
+*
+*  Other USES Files Needed: Common
+*
+*  Other Tool Sets Needed:  Tool Locator, Memory Manager
+*
+*  Copyright 1987-1992, 1993
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common;
+
+const
+   (* Scrap types *)
+   textScrap   =   0;
+   picScrap    =   1;
+
+   (* ShowClipboard flag values *)
+   cpOpenWindow  = $8000;
+   cpCloseWindow = $4000;
+
+type
+   scrapBuffer = record
+      scrapType: integer;
+      scrapSize: longint;
+      scrapHandle: handle;
+      end;
+
+procedure ScrapBootInit; tool ($16, $01);  (* WARNING: an application should
+                                                       NEVER make this call *)
+
+procedure ScrapStartup; tool ($16, $02);
+
+procedure ScrapShutDown; tool ($16, $03);
+
+function ScrapVersion: integer; tool ($16, $04);
+
+procedure ScrapReset; tool ($16, $05);     (* WARNING: an application should
+                                                       NEVER make this call *)
+
+function ScrapStatus: boolean; tool ($16, $06);
+
+procedure GetIndScrap (index: integer; buffer: scrapBuffer); tool ($16, $14);
+
+procedure GetScrap (destHandle: handle; scrapType: integer); tool ($16, $0D);
+
+function GetScrapCount: integer; tool ($16, $12);
+
+function GetScrapHandle (scrapType: integer): handle; tool ($16, $0E);
+
+function GetScrapPath: pathPtr; tool ($16, $10);
+
+function GetScrapSize (scrapType: integer): longint; tool ($16, $0F);
+
+function GetScrapState: integer; tool ($16, $13);
+
+procedure LoadScrap; tool ($16, $0A);
+
+procedure PutScrap (numBytes: longint; scrapType: integer; srcPtr: ptr);
+tool ($16, $0C);
+
+procedure SetScrapPath (var thePath: pathName); tool ($16, $11);
+
+procedure UnloadScrap; tool ($16, $09);
+
+procedure ZeroScrap; tool ($16, $0B);
+
+{new in 6.0.1}
+
+function ShowClipboard (flags: integer; zoomRect: rectPtr): grafPortPtr;
+tool ($16, $15);
+
+implementation
+end.

--- a/Tool.Interface/Sequencer.pas
+++ b/Tool.Interface/Sequencer.pas
@@ -1,0 +1,68 @@
+{$keep 'Sequencer'}
+unit Sequencer;
+interface
+
+{********************************************************
+*
+*  Note Sequencer Interface File
+*
+*  Other USES Files Needed: Common
+*
+*  Other Tool Sets Needed:  Tool Locator, Memory Manager
+*
+*  Copyright 1987-1992
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common;
+
+procedure SeqBootInit; tool ($1A, $01);   (* WARNING: an application should
+                                                      NEVER make this call *)
+
+procedure SeqStartup (dPageAddr, mode, updateRate, increment: integer);
+tool ($1A, $02);
+
+procedure SeqShutdown; tool ($1A, $03);
+
+function SeqVersion: integer; tool ($1A, $04);
+
+procedure SeqReset; tool ($1A, $05);      (* WARNING: an application should
+                                                      NEVER make this call *)
+
+function SeqStatus: boolean; tool ($1A, $06);
+
+function ClearIncr: integer; tool ($1A, $0A);
+
+(* The function GetLoc returns 3 words:            *)
+(*     curPhraseItem, curPattItem, and curLevel    *)
+(* function GetLoc: 3 words; tool ($1A, $0C);      *)
+
+function GetTimer: integer; tool ($1A, $0B);
+
+procedure SeqAllNotesOff; tool ($1A, $0D);
+
+procedure SetIncr (increment: integer); tool ($1A, $09);
+
+procedure SetInstTable (instTable: handle); tool ($1A, $12);
+
+procedure SetTrkInfo (priority, instIndex, trackNum: integer); tool ($1A, $0E);
+
+procedure StartInts; tool ($1A, $13);
+
+procedure StartSeq (errHndlrRoutine, compRoutine: procPtr; sequence: univ handle);
+tool ($1A, $0F);
+
+procedure StartSeqRel (errHndlrRtn, compRtn: procPtr; sequence: univ handle);
+tool ($1A, $15);
+
+procedure StepSeq; tool ($1A, $10);
+
+procedure StopInts; tool ($1A, $14);
+
+procedure StopSeq (next: boolean); tool ($1A, $11);
+
+implementation
+end.

--- a/Tool.Interface/SoundMgr.pas
+++ b/Tool.Interface/SoundMgr.pas
@@ -1,0 +1,132 @@
+{$keep 'SoundMgr'}
+unit SoundMgr;
+interface
+
+{********************************************************
+*
+*  Sound Manager Interface File
+*
+*  Other USES Files Needed: Common
+*
+*  Other Tool Sets Needed:  Tool Locator, Memory Manager
+*
+*  Copyright 1987-1990
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common;
+
+const
+   (* Channel-generator-type word *)
+   ffSynthMode     =   $0001;      (* free-form synthesizer mode *)
+   noteSynthMode   =   $0002;      (* note synthesizer mode      *)
+
+   (* Stop-sound mask *)
+   gen0off         =   $0001;
+   gen1off         =   $0002;
+   gen2off         =   $0004;
+   gen3off         =   $0008;
+   gen4off         =   $0010;
+   gen5off         =   $0020;
+   gen6off         =   $0040;
+   gen7off         =   $0080;
+   gen8off         =   $0100;
+   gen9off         =   $0200;
+   gen10off        =   $0400;
+   gen11off        =   $0800;
+   gen12off        =   $1000;
+   gen13off        =   $2000;
+   gen14off        =   $4000;
+
+(* Generator status word *)
+   genAvail        =   $0000;
+   ffSynth         =   $0100;
+   noteSynth       =   $0200;
+   lastBlock       =   $8000;
+
+
+type
+   soundPBPtr = ^soundParamBlock;
+   soundParamBlock = record
+       waveStart:     ptr;                 (* starting address of wave    *)
+       waveSize:      integer;             (* waveform size in pages      *)
+       freqOffset:    integer;             (* waveform playback frequency *)
+       DOCBuffer:     integer;             (* DOC buffer starting address *)
+       DOCBufferSize: integer;             (* DOC buffer size code        *)
+       nextWAddr:     soundPBPtr;          (* ptr to next waveform block  *)
+       volSetting:    integer;             (* DOC volume setting          *)
+       end;
+
+   DOCRegParamBlk = record
+       oscGenType:  integer;
+       freqLow1:    byte;                  (* 1st oscillator's parameters *)
+       freqHigh1:   byte;
+       vol1:        byte;
+       tablePtr1:   byte;
+       control1:    byte;
+       tableSize1:  byte;
+       freqLow2:    byte;                  (* 2nd oscillator's parameters *)
+       freqHigh2:   byte;
+       vol2:        byte;
+       tablePtr2:   byte;
+       control2:    byte;
+       tableSize2:  byte;
+       end;
+
+
+procedure SoundBootInit; tool ($08, $01);  (* WARNING: an application should
+                                                       NEVER make this call *)
+
+procedure SoundStartUp (WAP: integer); tool ($08, $02);
+
+procedure SoundShutDown; tool ($08, $03);
+
+function SoundVersion: integer; tool ($08, $04);
+
+procedure SoundReset; tool ($08, $05);     (* WARNING: an application should
+                                                       NEVER make this call *)
+
+function SoundToolStatus: boolean; tool ($08, $06);
+
+procedure FFSetUpSound (channelGen: integer;
+                        var paramBlockPtr: soundParamBlock); tool ($08, $15);
+
+function FFGeneratorStatus (genNumber: integer): integer;
+tool ($08, $11);
+
+function FFSoundDoneStatus (genNumber: integer): boolean; tool ($08, $14);
+
+function FFSoundStatus: integer; tool ($08, $10);
+
+procedure FFStartPlaying (genWord: integer); tool ($08, $16);
+
+procedure FFStartSound (genNumFFSynth: integer; var PBlockPtr: soundParamBlock);
+tool ($08, $0E);
+
+procedure FFStopSound (genMask: integer); tool ($08, $0F);
+
+function GetSoundVolume (genNumber: integer): integer; tool ($08, $0C);
+
+function GetTableAddress: longint; tool ($08, $0B);
+
+procedure ReadDOCReg (var DOCregParamBlkPtr: DOCregParamBlk); tool ($08, $18);
+
+procedure ReadRamBlock (destPtr: ptr; DOCStart, byteCount: integer);
+tool ($08, $0A);
+
+procedure SetDOCReg (var DOCRegParamBlock: DOCRegParamBlk); tool ($08, $17);
+
+procedure SetSoundMIRQV (sMasterIRQ: longint); tool ($08, $12);
+
+procedure SetSoundVolume (volume, genNumber: integer); tool ($08, $0D);
+
+function SetUserSoundIRQV (userIRQVector: longint): longint; tool ($08, $13);
+
+procedure WriteRamBlock (srcPtr: ptr; DOCStart, byteCount: integer);
+tool ($08, $09);
+
+implementation
+end.

--- a/Tool.Interface/Synthesizer.pas
+++ b/Tool.Interface/Synthesizer.pas
@@ -1,0 +1,85 @@
+{$keep 'Synthesizer'}
+unit Synthesizer;
+interface
+
+(********************************************************
+*
+*   Note Synthesizer Tool Set Interface File
+*
+*   Other USES Files Needed:  Common
+*
+*   Other tool sets needed:  Sound Tool Set
+*
+*  Copyright 1987-1990
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************)
+
+uses
+   Common;
+
+ type
+   waveForm = record
+     topKey:      byte;
+     waveAddress: byte;
+     waveSize:    byte;
+     DOCMode:     byte;
+     relPitch:    integer;
+     end;
+
+   instrument = record
+     envelope:          array [1..24] of byte;
+     releaseSegment:    byte;
+     priorityIncrement: byte;
+     pitchBendRange:    byte;
+     vibratoDepth:      byte;
+     vibratoSpeed:      byte;
+     spare:             byte;
+     aWaveCount:        byte;
+     bWaveCount:        byte;
+     aWaveList:         array [1..1] of waveForm; (* aWaveCount * 6 bytes *)
+     bWaveList:         array [1..1] of waveForm; (* bWaveCount * 6 bytes *)
+     end;
+
+   generatorControlBlock = record
+       synthID:       byte;
+       genNum:        byte;
+       semitone:      byte;
+       volume:        byte;
+       pitchBend:     byte;
+       vibratoDepth:  byte;
+       reserved:      array [1..10] of byte;
+       end;
+
+procedure NSBootInit; tool ($19, $01);     (* WARNING: an application should
+                                                       NEVER make this call *)
+
+procedure NSStartUp (updateRate: integer; updateRtn: procPtr) ; tool ($19, $02);
+
+procedure NSShutDown; tool ($19, $03);
+
+function NSVersion: integer; tool ($19, $04);
+
+procedure NSReset; tool ($19, $05);        (* WARNING: an application should
+                                                       NEVER make this call *)
+
+function NSStatus: boolean; tool ($19, $06);
+
+procedure AllNotesOff; tool ($19, $0D);
+
+function AllocGen (requestPriority: integer): integer; tool ($19, $09);
+
+procedure DeallocGen (genNum: integer); tool ($19, $0A);
+
+procedure NoteOff (genNum, semitone: integer); tool ($19, $0C);
+
+procedure NoteOn (genNum, semitone, volume: integer;
+                  var theInstrument: instrument); tool ($19, $0B);
+
+function NSSetUpdateRate (newRate: integer): integer; tool ($19, $0E);
+
+function NSSetUserUpdateRtn (newUpdateRtn: procPtr): procPtr; tool ($19, $0F);
+
+implementation
+end.

--- a/Tool.Interface/TextEdit.pas
+++ b/Tool.Interface/TextEdit.pas
@@ -1,0 +1,268 @@
+{$keep 'TextEdit'}
+unit TextEdit;
+interface
+
+{********************************************************
+*
+*   Text Edit Tool Set Interface File
+*
+*   Other USES Files Needed: Common
+*
+*   Other Tool Sets Needed:  Tool Locator, Miscellaneous Tool Set,
+*                            QuickDraw II, Event Manager,
+*                            Window Manager, Control Manager,
+*                            Menu Manager, QuickDraw Auxiliary,
+*                            Scrap Manager, Font Manager, Resource Manager
+*
+*  Copyright 1987-1990
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common, ControlMgr;
+
+const
+   (* Text Edit error codes *)
+   teAlreadyStarted    =   $2201;
+   teNotStarted        =   $2202;
+   teInvalidHandle     =   $2203;
+   teInvalidVerb       =   $2204;
+   teInvalidFlag       =   $2205;
+   teInvalidPCount     =   $2206;
+   teInvalidRect       =   $2207;
+   teBufferOverflow    =   $2208;
+   teInvalidLine       =   $2209;
+   teInvalidCall       =   $220A;
+   teInvalidParameter  =   $220B;
+   teInvalidTextBox2   =   $220C;
+
+   (* Text descriptors:  Bits 0-2 of descriptor word *)
+   dataIsPString       =   $000;
+   dataIsCString       =   $001;
+   dataIsC1Input       =   $002;
+   dataIsC1Output      =   $003;
+   dataIsTextBox2      =   $004;
+   dataIsTextBlock     =   $005;
+
+   (* Text Edit reference descriptors *)
+   teRefIsPtr          =   $0000;
+   teRefIsHandle       =   $0001;
+   teRefIsResource     =   $0002;
+   teRefIsNewHandle    =   $0003;
+
+type
+   teColorTablePtr = ^TEColorTable;
+   teColorTable = record
+       contentColor:         integer;
+       outlineColor:         integer;
+       hiliteForeColor:      integer;
+       hiliteBackColor:      integer;
+       vertColorDescriptor:  integer;
+       vertColorRef:         longint;
+       horzColorDescriptor:  integer;
+       horzColorRef:         longint;
+       growColorDescriptor:  integer;
+       growColorRef:         longint;
+       end;
+
+   teTextBlock = record
+       nextHandle: longint;
+       prevHandle: longint;
+       textLength: longint;
+       flags:      integer;
+       reserved:   integer;
+   (* Change size of array to suit your needs. *)
+       theText:    packed array [1..512] of text;
+       end;
+
+   superItem = record
+       theLength:  longint;
+       theData:    longint;
+       end;
+
+   superBlock = record
+       nextHandle:  longint;
+       prevHandle:  longint;
+       textLength:  longint;
+       reserved:    longint;
+   (* Change the array size to suit your needs. *)
+       theItems:    array [1..10] of superItem;
+       end;
+
+   (* Definitions of textList, superHandle, teStyle, and keyRecord can be *)
+   (* found in the Common.Intf interface file.                            *)
+
+   teHandle = ctlRecHndl;
+   teRecPtr = ctlPtr;
+   teTabItem = record
+       tabKind: integer;
+       tabData: integer;
+       end;
+
+   teRuler = record
+       leftMargin:     integer;
+       leftIndent:     integer;
+       rightMargin:    integer;
+       just:           integer;
+       extraLS:        integer;
+       flags:          integer;
+       userData:       longint;
+       tabType:        integer;
+   (* Change size of array for application. *)
+       tabs:           array [1..1] of teTabItem;
+       tabTerminator:  integer;
+       end;
+
+   teStyleGroupHndl = ^teStyleGroupPtr;
+   teStyleGroupPtr  = ^teStyleGroup;
+   teStyleGroup = record
+       count:   integer;
+   (* Change array size for application. *)
+       styles:  array [1..1] of teStyle;
+       end;
+
+   teStyleItem = record
+       length:  longint;
+       offset:  longint;
+       end;
+
+   teFormatHndl = ^teFormatPtr;
+   teFormatPtr  = ^teFormat;
+   teFormat = record
+       version:          integer;
+       rulerListLength:  longint;
+   (* Change array size for application. *)
+       theRulerList:     array [1..1] of teRuler;
+       styleListLength:  longint;
+   (* Change array size for application. *)
+       theStyleList:     array [1..1] of teStyle;
+       numberOfStyles:   longint;
+   (* Change array size for application. *)
+       theStyles:        array [1..1] of teStyleItem;
+       end;
+
+   teTextRef  = longint;
+   teStyleRef = longint;
+
+   (* The TEParamBlock record appears in the Resource Manager interface file *)
+   (* as editTextControl.                                                    *)
+
+   teInfoRec = record
+       charCount:     longint;
+       lineCount:     longint;
+       formatMemory:  longint;
+       totalMemory:   longint;
+       styleCount:    longint;
+       rulerCount:    longint;
+       end;
+
+   teHooks = record
+       charFilter:  procPtr;
+       wordWrap:    procPtr;
+       wordBreak:   procPtr;
+       drawText:    procPtr;
+       eraseText:   procPtr;
+       end;
+
+
+procedure TEBootInit; tool ($22, $01);
+
+procedure TEStartup (myId: integer; directPage: integer); tool ($22, $02);
+
+procedure TEShutDown; tool ($22, $03);
+
+function TEVersion: integer; tool ($22, $04);
+
+procedure TEReset; tool ($22, $05);
+
+function TEStatus: boolean; tool ($22, $06);
+
+procedure TEActivate (theTERecord: teHandle); tool ($22, $0F);
+
+procedure TEClear (theTERecord: teHandle); tool ($22, $19);
+
+procedure TEClick (var theEvent: eventRecord; theTERecord: teHandle);
+tool ($22, $11);
+
+procedure TECopy (theTERecord: teHandle); tool ($22, $17);
+
+procedure TECut (theTERecord: teHandle); tool ($22, $16);
+
+procedure TEDeactivate (theTERecord: teHandle); tool ($22, $10);
+
+function TEGetDefProc: procPtr; tool ($22, $22);
+
+procedure TEGetRuler (rulerDescriptor: integer; rulerRef: univ longint;
+                      theTERecord: teHandle); tool ($22, $23);
+
+procedure TEGetSelection (selectionStart, selectionEnd: univ ptr;
+                          theTERecord: teHandle); tool ($22, $1C);
+
+function TEGetSelectionStyle (var commonStyle: teStyle; 
+                              styleHandle: TEStyleGroupHndl;
+                              theTERecord: teHandle): integer; tool ($22, $1E);
+
+function TEGetText (bufferDescriptor: integer; bufferRef: univ longint;
+                    bufferLength: longint; styleDescriptor: integer;
+                    styleRef: univ longint; theTERecord: teHandle): longint;
+tool ($22, $0C);
+
+procedure TEGetTextInfo (var infoRec: teInfoRec; parameterCount: integer;
+                         theTERecord: teHandle); tool ($22, $0D);
+
+procedure TEIdle (theTERecord: teHandle); tool ($22, $0E);
+
+procedure TEInsert (textDescriptor: integer; textRef: teTextRef; 
+                    textLength: longint; styleDescriptor: integer; 
+                    styleRef: teStyleRef; theTERecord: teHandle);
+tool ($22, $1A);
+
+procedure TEInsertPageBreak; tool ($22, $23);
+
+procedure TEKey (var theEventRecord: eventRecord; theTERecord: teHandle);
+tool ($22, $14);
+
+procedure TEKill (theTERecord: teHandle); tool ($22, $0A);
+
+function TENew (var parameterBlock: editTextControl): teHandle; tool ($22, $09);
+
+procedure TEOffsetToPoint (textOffset: longint; vertPosPtr, horzPosPtr: ptr;
+                           theTERecord: teHandle); tool ($22, $20);
+
+function TEPaintText (thePort: grafPortPtr; startingLine: longint;
+                      var destRect: rect; flags: integer;
+                      theTERecord: teHandle): longint; tool ($22, $13);
+
+procedure TEPaste (theTERecord: teHandle); tool ($22, $18);
+
+function TEPointToOffset (vertPos, horzPos: longint; theTERecord: teHandle):
+                          longint; tool ($22, $21);
+
+procedure TEReplace (textDescriptor: integer; textRef: teTextRef; 
+                     textLength: longint; styleDescriptor: integer; 
+                     styleRef: teStyleRef; theTERecord: teHandle);
+tool ($22, $1B);
+
+procedure TEScroll (scrollDescriptor: integer; vertAmount, horzAmount: longint;
+                    theTERecord: teHandle); tool ($22, $25);
+
+procedure TESetRuler (rulerDescriptor: integer; rulerRef: univ longint;
+                      theTERecord: teHandle); tool ($22, $24);
+
+procedure TESetSelection (selectionStart, selectionEnd: longint; 
+                          theTEREcord: teHandle); tool ($22, $1D);
+
+procedure TESetText (textDescriptor: integer; textRef: teTextRef;
+                     textLength: longint; styleDescriptor: integer;
+                     styleRef: teStyleRef; theTERecord: teHandle);
+tool ($22, $0B);
+
+procedure TEStyleChange (flags: integer; var newStyle: teStyle;
+                         theTERecord: teHandle); tool ($22, $1F);
+
+procedure TEUpdate (theTERecord: TEHandle); tool ($22, $12);
+
+implementation
+end.

--- a/Tool.Interface/TextToolSet.pas
+++ b/Tool.Interface/TextToolSet.pas
@@ -1,0 +1,125 @@
+{$keep 'TextToolSet'}
+unit TextToolSet;
+interface
+
+{********************************************************
+*
+*  Text Tool Set Interface File
+*
+*  Other USES Files Needed: Common
+*
+*  Other Tool Sets Needed:  Tool Locator, Memory Manager
+*
+*  Copyright 1987-1989
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common;
+
+const
+   (* Echo flag values *)
+   noEcho      =   $0000;      (* don't echo chars to output device *)
+   echo        =   $0001;      (* echo chars to output device *)
+
+   (* Device numbers *)
+   inputDev    =   $0000;
+   outputDev   =   $0001;
+   errorOutputDev = $0002;
+
+   (* Device types *)
+   basicType   =   $0000;
+   pascalType  =   $0001;
+   ramBased    =   $0002;
+
+
+procedure TextBootInit; tool ($0C, $01);   (* WARNING: an application should
+                                                       NEVER make this call *)
+
+procedure TextStartup; tool ($0C, $02);
+
+procedure TextShutDown; tool ($0C, $03);
+
+function TextVersion: integer; tool ($0C, $04);
+
+procedure TextReset; tool ($0C, $05);      (* WARNING: an application should
+                                                       NEVER make this call *)
+
+function TextStatus: boolean; tool ($0C, $06);
+
+procedure CtlTextDev (deviceNumber, controlCode: integer); tool ($0C, $16);
+
+procedure ErrWriteBlock (theText: textBlock; offset, count: integer);
+tool ($0C, $1F);
+
+procedure ErrWriteChar (theChar: char); tool ($0C, $19);
+
+procedure ErrWriteCString (theCString: univ cStringPtr); tool ($0C, $21);
+
+procedure ErrWriteLine (theString: univ pStringPtr); tool ($0C, $1B);
+
+procedure ErrWriteString (theString: univ pStringPtr); tool ($0C, $1D);
+
+(* GetErrGlobals returns 2 words:  loWord = OR mask, hiWord = AND mask *)
+function GetErrGlobals: longint; tool ($0C, $0E);
+
+(* GetErrorDevice returns 1 integer and 1 longint.                     *)
+(* function GetErrorDevice: (deviceType: integer; ptrOrSlot: longint); *)
+(* tool ($0C, $14);                                                    *)
+
+(* GetInGlobals returns 2 words: loWord = OR mask, hiWord = AND mask *)
+function GetInGlobals: longint; tool ($0C, $0C);
+
+(* GetInputDevice returns 1 integer and 1 longint.                      *)
+(* function GetInputDevice: (deviceType: integer; ptrOrSlot: longint);  *)
+(* tool ($0C, $12);                                                     *)
+
+(* GetOutGlobals returns 2 words:  loWord = OR mask, hiWord = AND mask *)
+function GetOutGlobals: longint; tool ($0C, $0D);
+
+(* GetOutputDevice returns 1 integer and 1 longint.                     *)
+(* function GetOutputDevice: (deviceType: integer; ptrOrSlot: longint); *)
+(* tool ($0C, $13);                                                     *)
+
+procedure InitTextDev (deviceNum: integer); tool ($0C, $15);
+
+function ReadChar (echoFlag: boolean): char; tool ($0C, $22);
+
+function ReadLine (bufferPtr: ptr; maxCount: integer; endOfLine: char;
+                   echoFlag: boolean): integer; tool ($0C, $24);
+
+procedure SetErrGlobals (ANDMask, ORMask: integer); tool ($0C, $0B);
+
+procedure SetErrorDevice (deviceType: integer; slotOrPointer: longint);
+tool ($0C, $11);
+
+procedure SetInGlobals (ANDMask, ORMask: integer); tool ($0C, $09);
+
+procedure SetInputDevice (deviceType: integer; slotOrPointer: longint);
+tool ($0C, $0F);
+
+procedure SetOutGlobals (ANDMask, ORMask: integer); tool ($0C, $0A);
+
+procedure SetOutputDevice (deviceType: integer; slotOrPointer: longint);
+tool ($0C, $10);
+
+procedure StatusTextDev (deviceNum, requestCode: integer); tool ($0C, $17);
+
+procedure TextReadBlock (bufferPtr: ptr; offset, blockSize: integer;
+                         echoFlag: boolean); tool ($0C, $23);
+
+procedure TextWriteBlock (theText: univ textPtr; offset, count: integer);
+tool ($0C, $1E);
+
+procedure WriteChar (theChar: char); tool ($0C, $18);
+
+procedure WriteCString (theCString: univ cStringPtr); tool ($0C, $20);
+
+procedure WriteLine (theString: univ pStringPtr); tool ($0C, $1A);
+
+procedure WriteString (theString: univ pStringPtr); tool ($0C, $1C);
+
+implementation
+end.

--- a/Tool.Interface/ToolLocator.pas
+++ b/Tool.Interface/ToolLocator.pas
@@ -1,0 +1,149 @@
+{$keep 'ToolLocator'}
+unit ToolLocator;
+interface
+
+{********************************************************
+*
+*  Tool Locator Interface File
+*
+*  Other USES Files Needed: Common
+*
+*  Other Tool Sets Needed:  - None -
+*
+*  Copyright 1987-1992
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common;
+
+const
+   (* MessageCenter action codes *)
+   addMessage  =   1;          (* add message to msg center data *)
+   getMessage  =   2;          (* return message from msg center *)
+   deleteMessage = 3;          (* delete message from msg center *)
+
+
+type
+   (* Table of tools to load from the TOOLS directory in the SYSTEM folder *)
+   toolSpec = record
+       toolNumber: integer;
+       minVersion: integer;
+       end;
+
+   (* Change array size for your application. *)
+   ttArray = array [1..20] of toolSpec;
+    
+   toolTable = record
+       numToolsRequired:  integer;
+       tool:              ttArray;
+       end;
+
+   startStopRecord = record
+       flags:        integer;
+       videoMode:    integer;
+       resFileID:    integer;
+       DPageHandle:  handle;
+       numTools:     integer;
+       toolArray:    ttArray;
+       end;
+   startStopRecordPtr = ^startStopRecord;
+      
+   (* Function pointer table *)
+   FPT = record
+       count: longint;          (* number of functions plus 1             *)
+       addr1: ptr;              (* ptr to BootInit routine minus 1        *)
+       addr2: ptr;              (* ptr to StartUp routine minus 1         *)
+       addr3: ptr;              (* ptr to ShutDown routine minus 1        *)
+       addr4: ptr;              (* ptr to Version routine minus 1         *)
+       addr5: ptr;              (* ptr to Reset routine minus 1           *)
+       addr6: ptr;              (* ptr to Status routine minus 1          *)
+       addr7: ptr;              (* ptr to reserved routine minus 1        *)
+       addr8: ptr;              (* ptr to reserved routine minus 1        *)
+       addr9: ptr;              (* ptr to 1st nonrequired routine minus 1 *)
+   (* Other pointers to additional nonrequired routines, each minus 1     *)
+       addr: array [1..50] of ptr;
+       end;
+
+   messageRecord = record
+       blockLength: integer;
+       IDstring:    pString;   (* may be a max of 64 chars long *)
+   (* Change length of array to suit application. *)
+       dataBlock:   packed array [1..1] of byte;
+       end;
+
+
+procedure TLBootInit; tool ($01, $01);     (* WARNING: an application should
+                                                       NEVER make this call *)
+
+procedure TLStartup; tool ($01, $02);
+
+procedure TLShutDown; tool ($01, $03);
+
+function TLVersion: integer; tool ($01, $04);
+
+procedure TLReset; tool ($01, $05);        (* WARNING: an application should
+                                                       NEVER make this call *)
+
+function TLStatus: boolean; tool ($01, $06);
+
+procedure AcceptRequests (nameString: pString; userID: integer;
+   requestProc: ptr); tool ($01, $1B);
+
+function GetFuncPtr (userOrSystem: integer; funcNum_TSNum: integer): longint;
+tool ($01, $0B);
+
+function GetMsgHandle (flags: integer; messageRef: univ longint): longint;
+tool ($01, $1A);
+
+function GetTSPtr (userOrSystem, tsNum: integer): longint; tool ($01, $09);
+
+function GetWAP (userOrSystem, tsNum: integer): longint; tool ($01, $0C);
+
+procedure LoadOneTool (toolNumber, minVersion: integer); tool ($01, $0F);
+
+procedure LoadTools (var theToolTable: toolTable); tool ($01, $0E);
+
+(* MessageByName returns two words:  lo word = message number  *)
+(*                                   hi word = boolean flag    *)
+function MessageByName (createItFlag: boolean; var inputRecord: messageRecord):
+                        longint; tool ($01, $17);
+
+procedure MessageCenter (action, msgID: integer; messageHandle: handle);
+tool ($01, $15);
+
+procedure RestoreTextState (stateHandle: handle); tool ($01, $14);
+
+function SaveTextState: handle; tool ($01, $13);
+
+procedure SendRequest (reqCode, sendHow: integer; target, dataIn: univ longint;
+   dataOut: ptr); tool ($01, $1C);
+
+procedure SetDefaultTPT; tool ($01, $16);  (* WARNING: an application should
+                                                       NEVER make this call *)
+
+procedure SetTSPtr (userOrSystem, tsNum: integer; theFPT: FPT);
+tool ($01, $0A);
+
+procedure SetWAP (userOrSystem, tsNum: integer; waptPtr: ptr);
+tool ($01, $0D);
+
+procedure ShutDownTools (startStopVerb: integer;
+                         startStopRecRef: univ longint); tool ($01, $19);
+
+function StartupTools (myID, startStopVerb: integer;
+                       startStopRecRef: univ longint): longint;
+tool ($01, $18);
+ 
+function TLMountVolume (whereX, whereY: integer; line1Ptr, line2Ptr,
+                        but1Ptr, but2Ptr: pStringPtr): integer; tool ($01, $11);
+
+function TLTextMountVolume (line1Ptr, line2Ptr, button1Ptr, button2Ptr:
+                            pStringPtr): integer; tool ($01, $12);
+
+procedure UnloadOneTool (toolNumber: integer); tool ($01, $10);
+
+implementation
+end.

--- a/Tool.Interface/WindowMgr.pas
+++ b/Tool.Interface/WindowMgr.pas
@@ -1,0 +1,475 @@
+{$keep 'WindowMgr'}
+unit WindowMgr;
+interface
+
+{********************************************************
+*
+*  Window Manager Interface File
+*
+*  Other USES Files Needed: Common
+*
+*  Other Tool Sets Needed:  Tool Locator, Memory Manager,
+*                           Miscellaneous Tool Set, QuickDraw II,
+*                           Event Manager
+*
+*  Copyright 1987-1992, 1993
+*  By the Byte Works, Inc.
+*  All Rights Reserved
+*
+*********************************************************}
+
+uses
+   Common;
+
+const
+   (* Axis parameters *)
+   wNoConstraint   =   $0000;      (* no constraint on movement *)
+   wHAxisOnly      =   $0001;      (* horizontal axis only      *)
+   wVAxisOnly      =   $0002;      (* vertical axis only        *)
+
+   (* Desktop commands *)
+   fromDesk        =   $00;        (* subtract region from desktop           *)
+   toDesk          =   $01;        (* add region to desktop                  *)
+   getDesktop      =   $02;        (* get handle to desktop region           *)
+   setDesktop      =   $03;        (* set handle to desktop region           *)
+   getDeskPat      =   $04;        (* address of pattern or drawing rtn      *)
+   setDeskPat      =   $05;        (* change addr of pattern or drawing rtn  *)
+   getVisDesktop   =   $06;        (* get desktop rgn, minus visible windows *)
+   backgroundRgn   =   $07;        (* for drawing directly on desktop        *)
+
+   (* SendBehind values *)
+   toBottom        =   -2;         (* send window to bottom *)
+   topMost         =   -1;         (* make window frontmost *)
+   bottomMost      =   $0000;      (* make window bottom    *)
+
+   (* Task mask values *)
+   tmMenuKey           =   $00000001;  (* handle menu key events              *)
+   tmUpdate            =   $00000002;  (* handle update events                *)
+   tmFindW             =   $00000004;  (* FindWindow called                   *)
+   tmMenuSel           =   $00000008;  (* MenuSelect called                   *)
+   tmOpenNDA           =   $00000010;  (* OpenNDA called                      *)
+   tmSysClick          =   $00000020;  (* SystemClick called                  *)
+   tmDragW             =   $00000040;  (* DragWindow called                   *)
+   tmContent           =   $00000080;  (* activate window if click in content *)
+                                       (*  region                             *)
+   tmClose             =   $00000100;  (* TrackGoAway called                  *)
+   tmZoom              =   $00000200;  (* TrackZoom called                    *)
+   tmGrow              =   $00000400;  (* GrowWindow called                   *)
+   tmScroll            =   $00000800;  (* enable scrolling; activate window   *)
+                                       (*   on click in scroll bar            *)
+   tmSpecial           =   $00001000;  (* handle special menu events          *)
+   tmCRedraw           =   $00002000;  (* redraw controls                     *)
+   tmInactive          =   $00004000;  (* allow select of inactive menu items *)
+   tmInfo              =   $00008000;  (* don't activate inactive window on   *)
+                                       (*   click in information bar          *)
+   tmContentControls   =   $00010000;  (* track controls in content region    *)
+   tmControlKey        =   $00020000;  (* send keystrokes to controls in      *)
+                                       (*   active window                     *)
+   tmControlMenu       =   $00040000;  (* send menu selections to controls in *)
+                                       (*   active window                     *)
+   tmMultiClick        =   $00080000;  (* track double and triple clicks      *)
+   tmIdleEvents        =   $00100000;  (* send null events to active control  *)
+                                       (*   in active window                  *)
+   tmNoGetNextEvent    =   $00200000;  (* don't call GetNextEvent             *)
+
+   (* varCode values when defining custom windows *)
+   wDraw           =   $00;        (* draw window frame command *)
+   wHit            =   $01;        (* hit test command          *)
+   wCalcRgns       =   $02;        (* compute regions command   *)
+   wNew            =   $03;        (* initialization command    *)
+   wDispose        =   $04;        (* dispose command           *)
+
+   (* wFrame values *)
+   fHilited        =   $0001;      (* window is highlighted                 *)
+   fZoomed         =   $0002;      (* window is zoomed                      *)
+   fAllocated      =   $0004;      (* window record was allocated           *)
+   fCtlTie         =   $0008;      (* state of ctls tied to window's state  *)
+   fInfo           =   $0010;      (* window has information bar            *)
+   fVis            =   $0020;      (* window is visible                     *)
+   fQContent       =   $0040;      (* select window if mousedown in content *)
+   fMove           =   $0080;      (* window can be dragged                 *)
+   fZoom           =   $0100;      (* window has a zoom box                 *)
+   fFlex           =   $0200;      (* data height and width are flexible    *)
+   fGrow           =   $0400;      (* window has a size box                 *)
+   fBScroll        =   $0800;      (* window has horizontal scroll bar      *)
+   fRScroll        =   $1000;      (* window has vertical scroll bar        *)
+   fAlert          =   $2000;      (* alert-type window frame               *)
+   fClose          =   $4000;      (* window has close box                  *)
+   fTitle          =   $8000;      (* window has title bar                  *)
+
+   (* Record sizes *)
+   windSize        =   $145;       (* size of window record *)
+   wmTaskRecSize   =   $16;        (* size of task record   *)
+
+   (* UpdateWindow flag values *)
+   uwBackground    =   $8000;
+   uwGSOSnotAvail  =   $4000;
+   
+type
+   (* Document and alert window color table *)
+   wColorTbl = record
+       frameColor: integer;
+       titleColor: integer;
+       tBarColor:  integer;
+       growColor:  integer;
+       infoColor:  integer;
+       end;
+   wColorPtr = ^wColorTbl;
+
+   (* Window record *)
+   windRecPtr = ^windRec;
+   windRec = record
+       wNext:       windRecPtr;
+       wPort:       array [1..170] of byte;
+       wDefProc:    longint;
+       wRefCon:     longint;
+       wContDraw:   procPtr;
+       wReserved:   longint;
+       wStructRgn:  handle;
+       wContRgn:    handle;
+       wUpdateRgn:  handle;
+       wCtls:       handle;
+       wFrameCtls:  handle;
+       wFrame:      integer;
+   (* Other fields may be added here, as defined by window's defProc. *)
+       end;
+
+   paramTableRef = record
+       p1Length:       integer;
+       p1Frame:        integer;
+       p1Title:        longint;
+       p1RefCon:       longint;
+       p1Zoom:         rect;
+       p1Color:        longint;
+       p1YOrigin:      integer;
+       p1XOrigin:      integer;
+       p1DataH:        integer;
+       p1DataW:        integer;
+       p1MaxH:         integer;
+       p1MaxW:         integer;
+       p1VerScroll:    integer;
+       p1HorScroll:    integer;
+       p1VerPage:      integer;
+       p1HorPage:      integer;
+       p1InfoText:     longint;
+       p1InfoHeight:   integer;
+       p1DefProc:      procPtr;
+       p1InfoDraw:     procPtr;
+       p1ContentDraw:  procPtr;
+       p1Position:     rect;
+       p1Plane:        longint;
+       p1ControlList:  longint;
+       p1InVerb:       integer;
+       end;
+
+   (* original Window parameter list *)
+   paramList = record
+       paramLength:   integer;
+       wFrameBits:    integer;
+       wTitle:        pStringPtr;
+       wRefCon:       longint;
+       wZoom:         rect;
+       wColor:        wColorPtr;
+       wYOrigin:      integer;
+       wXOrigin:      integer;
+       wDataH:        integer;
+       wDataW:        integer;
+       wMaxH:         integer;
+       wMaxW:         integer;
+       wScrollVer:    integer;
+       wScrollHor:    integer;
+       wPageVer:      integer;
+       wPageHor:      integer;
+       wInfoRefCon:   longint;
+       wInfoHeight:   integer;
+       wFrameDefProc: procPtr;
+       wInfoDefProc:  procPtr;
+       wContDefProc:  procPtr;
+       wPosition:     rect;
+       wPlane:        grafPortPtr;
+       wStorage :     windRecPtr;    (* address of memory for window record *)
+       end;
+   paramListPtr = ^paramList;
+
+   deskMessage = record
+       reserved:  longint;
+       messType:  integer;         (* must be 2 *)
+       drawType:  integer;         (* 0 = pattern; 1 = picture *)
+   (* drawData = 32 bytes of pattern or 32,000 bytes of picture data *)
+       drawData:  array [1..32] of byte;
+       end;
+
+
+(* wmTaskRec is an Event Record, defined in the Common.intf interface file.  *)
+
+
+procedure WindBootInit; tool ($0E, $01);   (* WARNING: an application should
+                                                       NEVER make this call *)
+
+procedure WindStartup (userID: integer); tool ($0E, $02);
+
+procedure WindShutDown; tool ($0E, $03);
+
+function WindVersion: integer; tool ($0E, $04);
+
+procedure WindReset; tool ($0E, $05);      (* WARNING: an application should
+                                                       NEVER make this call *)
+
+function WindStatus: boolean; tool ($0E, $06);
+
+function AlertWindow (alertFlags: integer; subStrPtr: ptr;
+                      alertStrPtr: univ longint): integer; tool ($0E, $59);
+
+procedure BeginUpdate (theWindow: grafPortPtr); tool ($0E, $1E);
+
+procedure BringToFront (theWindow: grafPortPtr); tool ($0E, $24);
+
+function CheckUpdate (var theEvent: eventRecord): boolean; tool ($0E, $0A);
+
+procedure CloseWindow (theWindow: grafPortPtr); tool ($0E, $0B);
+
+function CompileText (subType: integer; subStringsPtr, srcStringsPtr: univ ptr;
+                      srcSize: integer): handle; tool ($0E, $60);
+      
+function Desktop (deskTopOp: integer; dtParam: longint): longint;
+tool ($0E, $0C);
+
+function DoModalWindow (event: eventRecord;
+   updateProc, eventHook, beepProc: procPtr; flags: integer): longint;
+   tool ($0E, $64);
+
+procedure DragWindow (grid, startX, startY, grace: integer;
+                      var boundsRect: rect; theWindow: grafPortPtr);
+tool ($0E, $1A);
+
+procedure DrawInfoBar (theWindow: grafPortPtr); tool ($0E, $55);
+
+procedure EndFrameDrawing; tool ($0E, $5B);
+
+procedure EndInfoDrawing; tool ($0E, $51);
+
+procedure EndUpdate (theWindow: grafPortPtr); tool ($0E, $1F);
+
+function ErrorWindow (subType: integer; subStringPtr: univ ptr;
+                      errNum: integer): integer; tool ($0E, $62);
+
+function FindCursorCtl (var ctl: ctlRecHndl; xLoc, yLoc: integer;
+   theWindow: grafPortPtr): integer; tool ($0E, $69);
+
+function FindWindow (var whichWindow: grafPortPtr; pointX, pointY: integer):
+                     integer; tool ($0E, $17);
+
+function FrontWindow: grafPortPtr; tool ($0E, $15);
+
+function GetAuxWindInfo (theWindow: grafPortPtr): longint; tool ($0E, $63);
+
+function GetContentDraw (theWindow: grafPortPtr): procPtr; tool ($0E, $48);
+
+(* GetContentOrigin returns 2 words: loWord = Y origin, hiWord = X origin *)
+(* Apple has consistently switched between two spellings for this call.   *)
+(* Since it has become impossible to tell what they will do next, both    *)
+(* spellings are included here.                                           *)
+function GetContentOrigin (theWindow: grafPortPtr): longint; tool ($0E, $3E);
+function GetContentOrgin (theWindow: grafPortPtr): longint; tool ($0E, $3E);
+
+function GetContentRgn (theWindow: grafPortPtr): longint; tool ($0E, $2F);
+
+(* GetDataSize returns 2 words: loWord = height, hiWord = width *)
+function GetDataSize (theWindow: grafPortPtr): longint; tool ($0E, $40);
+
+function GetDefProc (theWindow: grafPortPtr): procPtr; tool ($0E, $31);
+
+function GetFirstWindow: grafPortPtr; tool ($0E, $52);
+
+procedure GetFrameColor (var newColor: wColorTbl; theWindow: grafPortPtr);
+tool ($0E, $10);
+
+function GetInfoDraw (theWindow: grafPortPtr): procPtr; tool ($0E, $4A);
+
+function GetInfoRefCon (theWindow: grafPortPtr): longint; tool ($0E, $35);
+
+(* GetMaxGrow returns 2 words: loWord = maxHeight, hiWord = maxWidth *)
+function GetMaxGrow (theWindow: grafPortPtr): longint; tool ($0E, $42);
+
+function GetNextWindow (theWindow: grafPortPtr): grafPortPtr; tool ($0E, $2A);
+
+(* GetPage returns 2 words: loWord = vertical amt, hiWord = horizontal amt *)
+function GetPage (theWindow: grafPortPtr): longint; tool ($0E, $46);
+
+procedure GetRectInfo (var infoRect: rect; theWindow: grafPortPtr);
+tool ($0E, $4F);
+
+(* GetScroll returns 2 words: loWord = vertical amt, hiWord = horizontal amt *)
+function GetScroll (theWindow: grafPortPtr): longint; tool ($0E, $44);
+
+function GetStructRgn (theWindow: grafPortPtr): rgnHandle; tool ($0E, $2E);
+
+function GetSysWFlag (theWindow: grafPortPtr): boolean; tool ($0E, $4C);
+
+function GetUpdateRgn (theWindow: grafPortPtr): rgnHandle; tool ($0E, $30);
+
+function GetWControls (theWindow: grafPortPtr): ctlRecHndl; tool ($0E, $33);
+
+function GetWFrame (theWindow: grafPortPtr): integer; tool ($0E, $2C);
+
+function GetWindowMgrGlobals: ptr; tool ($0E, $58);
+
+function GetWKind (theWindow: grafPortPtr): integer; tool ($0E, $2B);
+
+function GetWMgrPort: grafPortPtr; tool ($0E, $20);
+
+function GetWRefCon (theWindow: grafPortPtr): longint; tool ($0E, $29);
+
+function GetWTitle (theWindow: grafPortPtr): pStringPtr; tool ($0E, $0E);
+
+function GetZoomRect (theWindow: grafPortPtr): rectPtr; tool ($0E, $37);
+
+(* GrowWindow returns 2 words: loWord = new height, hiWord = new width *)
+function GrowWindow (minWidth, minHeight, startX, startY: integer;
+                     theWindow: grafPortPtr): longint; tool ($0E, $1B);
+
+(* HandleDiskInsertreturns 2 words: loWord = dev num, hiWord = flags *)
+function HandleDiskInsert (flags, devNum: integer): longint; tool ($0E, $6B);
+
+procedure HideWindow (theWindow: grafPortPtr); tool ($0E, $12);
+
+procedure HiliteWindow (fHiliteFlag: boolean; theWindow: grafPortPtr);
+tool ($0E, $22);
+
+procedure InvalRect (var badRect: rect); tool ($0E, $3A);
+
+procedure InvalRgn (badRgn: rgnHandle); tool ($0E, $3B);
+
+procedure MoveWindow (newX, newY: integer; theWindow: grafPortPtr);
+tool ($0E, $19);
+
+function MWGetCtlPart: integer; tool ($0E, $65);
+
+function MWSetMenuProc (newMenuProc: procPtr): procPtr; tool ($0E, $66);
+
+procedure MWSetUpEditMenu; tool ($0E, $68);
+
+procedure MWStdDrawProc; tool ($0E, $67);
+
+function NewWindow (paramListPtr: paramList): grafPortPtr; tool ($0E, $09);
+
+function NewWindow2 (titlePtr: pStringPtr; refCon: univ longint;
+                     contentDrawPtr, defProcPtr: procPtr;
+                     paramTableDescriptor: integer;
+                     paramTableRef:  univ longint;
+                     resourceType: integer): grafPortPtr; tool ($0E, $61);
+
+(* PinRect returns a point: loWord = Y coordinate, hiWord = X coordinate *)
+function PinRect (xPoint, yPoint: integer; var theRect: rect): longint;
+tool ($0E, $21);
+
+procedure RefreshDesktop (redrawRect: rectPtr); tool ($0E, $39);
+
+procedure ResizeInfoBar (flags, newSize: integer; theWindow: grafPortPtr);
+tool ($0E, $6A);
+
+procedure ResizeWindow (hiddenFlag: boolean; var theRect: rect;
+                        theWindow: grafPortPtr); tool ($0E, $5C);
+
+procedure SelectWindow (theWindow: grafPortPtr); tool ($0E, $11);
+
+procedure SendBehind (behindWindow, theWindow: grafPortPtr); tool ($0E, $14);
+
+procedure SetContentDraw (contDraw: procPtr; theWindow: grafPortPtr);
+tool ($0E, $49);
+
+procedure SetContentOrigin (xOrigin, yOrigin: integer; theWindow: grafPortPtr);
+tool ($0E, $3F);
+
+procedure SetContentOrigin2 (scrollFlag, xOrigin, yOrigin: integer;
+                             theWindow: grafPortPtr); tool ($0E, $57);
+
+procedure SetDataSize (dataWidth, dataHeight: integer; theWindow: grafPortPtr);
+tool ($0E, $41);
+
+procedure SetDefProc (wDefProc: procPtr; theWindow: grafPortPtr);
+tool ($0E, $32);
+
+procedure SetFrameColor (newColor: wColorPtr; theWindow: grafPortPtr);
+tool ($0E, $0F);
+
+procedure SetInfoDraw (infoDraw: procPtr; theWindow: grafPortPtr);
+tool ($0E, $16);
+
+procedure SetInfoRefCon (infoRefCon: longint; theWindow: grafPortPtr);
+tool ($0E, $36);
+
+procedure SetMaxGrow (maxWidth, maxHeight: integer; theWindow: grafPortPtr);
+tool ($0E, $43);
+
+procedure SetOriginMask (originMask: integer; theWindow: grafPortPtr);
+tool ($0E, $34);
+
+procedure SetPage (hPage, vPage: integer; theWindow: grafPortPtr);
+tool ($0E, $47);
+
+procedure SetScroll (hScroll, vScroll: integer; theWindow: grafPortPtr);
+tool ($0E, $45);
+
+procedure SetSysWindow (theWindow: grafPortPtr); tool ($0E, $4B);
+
+procedure SetWFrame (wFrame: integer; theWindow: grafPortPtr); tool ($0E, $2D);
+
+function SetWindowIcons (newFontHandle: handle): handle; tool ($0E, $4E);
+
+procedure SetWRefCon (wRefCon: longint; theWindow: grafPortPtr); tool ($0E, $28);
+
+procedure SetWTitle (title: univ pStringPtr; theWindow: grafPortPtr); tool ($0E, $0D);
+
+procedure SetZoomRect (var wZoomSize: rect; theWindow: grafPortPtr);
+tool ($0E, $38);
+
+procedure ShowHide (showFlag: boolean; theWindow: grafPortPtr); tool ($0E, $23);
+
+procedure ShowWindow (theWindow: grafPortPtr); tool ($0E, $13);
+
+procedure SizeWindow (newWidth, newHeight: integer; theWindow: grafPortPtr);
+tool ($0E, $1C);
+
+procedure StartDrawing (theWindow: grafPortPtr); tool ($0E, $4D);
+
+procedure StartFrameDrawing (theWindow: grafPortPtr); tool ($0E, $5A);
+
+procedure StartInfoDrawing (var infoRect: rect; theWindow: grafPortPtr);
+tool ($0E, $50);
+
+function TaskMaster (taskMask: integer; var theTaskRec: eventRecord): integer;
+tool ($0E, $1D);
+
+function TaskMasterDA (eventMask: integer; var taskRecPtr: eventRecord): integer;
+tool ($0E, $5F);
+
+function TrackGoAway (startX, startY: integer; theWindow: grafPortPtr):
+                      boolean; tool ($0E, $18);
+
+function TrackZoom (startX, startY: integer; theWindow: grafPortPtr): boolean;
+tool ($0E, $26);
+
+procedure ValidRect (var goodRect: rect); tool ($0E, $3C);
+
+procedure ValidRgn (goodRgn: rgnHandle); tool ($0E, $3D);
+
+(* WindDragRect returns 2 words:  loWord = change in Y, hiWord = change in X *)
+function WindDragRect (actionProc: procPtr; var dragPatternPtr: pattern;
+                       startX, startY: integer;
+                       var dragRect, limitRect, slopRect: rect;
+                       dragFlag: integer): longint; tool($0E, $53);
+
+procedure WindNewRes; tool ($0E, $25);
+
+function WindowGlobal (windowGlobalMask: integer): integer; tool ($0E, $56);
+
+procedure ZoomWindow (theWindow: grafPortPtr); tool ($0E, $27);
+
+{new in 6.0.1}
+
+procedure UpdateWindow (flags: integer; theWindow: grafPortPtr);
+tool ($0E, $6C);
+
+implementation
+end.


### PR DESCRIPTION
This change involves bringing all of the Tool.Interface/=.pas files from the OPUS package so that we can maintain the Pascal interfaces to the ToolKits in the same place.

With the files in place, I've also corrected the setFileInfoOSDCB type and increased the default size of a GSOSInString to 508 bytes so that it works with more of the GSOS tool calls.