### PR TITLE
Avoid overflow in computation of whether a case statement is sparse

### DIFF
--- a/parser.pas
+++ b/parser.pas
@@ -3737,7 +3737,7 @@ end; {DoConstant}
     Gen1(dc_lab, lcix);
     if fstptr <> nil then begin		{if there are labels...}
       lmin := fstptr^.cslab;
-      if (lmax - lmin) div lcount > sparse then begin
+      if (ord4(lmax) - lmin) div lcount > sparse then begin
 
         {use if-else for sparse case statements}
         while fstptr <> nil do begin


### PR DESCRIPTION
If the difference between the minimum and maximum values in a case statement was greater than 32767, there would be an integer overflow in the computation of whether the case statement was sparse. That would cause the case statement to be treated as non-sparse, so a jump table would be generated for it, but that jump table would be very large, so it would overflow the object buffer and cause an error (misleadingly reported as "not iso standard").

Here is an example of a program affected by this:
```
program CaseBug(input,output);

var
	x: integer;

begin
readln(x);
case x of
	maxint: writeln('maxint');
	-maxint: writeln('-maxint');
	otherwise writeln('other');
	end;
end.
```